### PR TITLE
Only remake $(TARGET_BASE).elf el al. if necessary

### DIFF
--- a/build/module.mk
+++ b/build/module.mk
@@ -82,9 +82,7 @@ ALLDEPS += $(addprefix $(BUILD_PATH)/, $(patsubst $(COMMON_BUILD)/arm/%,%,$(ASRC
 CLOUD_FLASH_URL ?= https://api.spark.io/v1/devices/$(SPARK_CORE_ID)\?access_token=$(SPARK_ACCESS_TOKEN)
 
 # All Target
-all: $(TARGET) postbuild
-
-build_dependencies: $(MAKE_DEPENDENCIES)
+all: $(MAKE_DEPENDENCIES) $(TARGET) postbuild
 
 elf: $(TARGET_BASE).elf
 bin: $(TARGET_BASE).bin
@@ -95,13 +93,13 @@ exe: $(TARGET_BASE)$(EXECUTABLE_EXTENSION)
 none:
 	;
 
-st-flash: $(TARGET_BASE).bin
+st-flash: $(MAKE_DEPENDENCIES) $(TARGET_BASE).bin
 	@echo Flashing $< using st-flash to address $(PLATFORM_DFU)
 	st-flash write $< $(PLATFORM_DFU)
 
 ifneq ("$(OPENOCD_HOME)","")
 
-program-openocd: $(TARGET_BASE).bin
+program-openocd: $(MAKE_DEPENDENCIES) $(TARGET_BASE).bin
 	@echo Flashing $< using openocd to address $(PLATFORM_DFU)
 	$(OPENOCD_HOME)/openocd -f $(OPENOCD_HOME)/tcl/interface/ftdi/particle-ftdi.cfg -f $(OPENOCD_HOME)/tcl/target/stm32f2x.cfg  -c "init; reset halt" -c "flash protect 0 0 11 off" -c "program $< $(PLATFORM_DFU) reset exit"
 
@@ -109,7 +107,7 @@ endif
 
 # Program the core using dfu-util. The core should have been placed
 # in bootloader mode before invoking 'make program-dfu'
-program-dfu: $(TARGET_BASE).dfu
+program-dfu: $(MAKE_DEPENDENCIES) $(TARGET_BASE).dfu
 ifdef START_DFU_FLASHER_SERIAL_SPEED
 # PARTICLE_SERIAL_DEV should be set something like /dev/tty.usbxxxx and exported
 #ifndef PARTICLE_SERIAL_DEV
@@ -126,11 +124,11 @@ endif
 
 # Program the core using the cloud. SPARK_CORE_ID and SPARK_ACCESS_TOKEN must
 # have been defined in the environment before invoking 'make program-cloud'
-program-cloud: $(TARGET_BASE).bin
+program-cloud: $(MAKE_DEPENDENCIES) $(TARGET_BASE).bin
 	@echo Flashing using cloud API, CORE_ID=$(SPARK_CORE_ID):
 	$(CURL) -X PUT -F file=@$< -F file_type=binary $(CLOUD_FLASH_URL)
 
-program-serial: $(TARGET_BASE).bin
+program-serial: $(MAKE_DEPENDENCIES) $(TARGET_BASE).bin
 ifdef START_YMODEM_FLASHER_SERIAL_SPEED
 # Program core/photon using serial ymodem flasher.
 # Install 'sz' tool using: 'brew install lrzsz' on MAC OS X
@@ -218,14 +216,14 @@ endif
 	$(call echo,)
 
 
-$(TARGET_BASE).elf : build_dependencies $(ALLOBJ) $(LIB_DEPS) $(LINKER_DEPS)
+$(TARGET_BASE).elf : $(ALLOBJ) $(LIB_DEPS) $(LINKER_DEPS)
 	$(call echo,'Building target: $@')
 	$(call echo,'Invoking: ARM GCC C++ Linker')
 	$(VERBOSE)$(MKDIR) $(dir $@)
 	$(VERBOSE)$(CPP) $(CFLAGS) $(ALLOBJ) --output $@ $(LDFLAGS)
 	$(call echo,)
 
-$(TARGET_BASE)$(EXECUTABLE_EXTENSION) : build_dependencies $(ALLOBJ) $(LIB_DEPS) $(LINKER_DEPS)
+$(TARGET_BASE)$(EXECUTABLE_EXTENSION) : $(ALLOBJ) $(LIB_DEPS) $(LINKER_DEPS)
 	$(call echo,'Building target: $@')
 	$(call echo,'Invoking: GCC C++ Linker')
 	$(VERBOSE)$(MKDIR) $(dir $@)


### PR DESCRIPTION
Commit ee1d29e made it possible to run program-dfu and friends without
first running `make all`, but it also made it so the $(TARGET_BASE).elf
recipe is constantly executed, whether it needs it or not.

The problem is that currently, $(MAKE_DEPENDENCIES) is phony, so real
targets shouldn't depend on that [1]. Phony prerequisites are never up
to date, so neither is anything that depends on them, and make rebuilds
anything that isn't up to date.

One solution is to move the phony prerequisites from the real targets to
program-dfu, which is itself phony. That's how the `all` target worked
before ee1d29e.

[1] https://www.gnu.org/software/make/manual/html_node/Phony-Targets

---

Doneness:

- [x] Contributor has signed CLA
- [ ] Problem and Solution clearly stated
- [ ] Code peer reviewed
- [ ] API tests compiled
- [ ] Run unit/integration/application tests on device
- [ ] Add documentation
- [ ] Add to CHANGELOG.md after merging (add links to docs and issues)