### PR TITLE
use 'using std::**' instead of define * std::*

### DIFF
--- a/wiring/inc/spark_wiring_arduino.h
+++ b/wiring/inc/spark_wiring_arduino.h
@@ -171,11 +171,11 @@ typedef volatile uint32_t RwReg;
 #ifdef __cplusplus
 
 #ifndef isnan
-#define isnan std::isnan
+using std::isnan;
 #endif
 
 #ifndef isinf
-#define isinf std::isinf
+using std::isinf;
 #endif
 
 


### PR DESCRIPTION
**Summary of Commits:**
Fix C++ build using std::isnan or std::isinf with explicit namespace specification

**Problem:** 
Using define for using c++ namespaces breaking compilation when names are used with explicit namespace specification. So std::isnan converts to std::std::isnan.

**Solution:** 
use c++ _using_ keyword insead of define.

---

Doneness:

- [ ] Contributor has signed CLA
- [ ] Problem and Solution clearly stated
- [ ] Code peer reviewed
- [ ] API tests compiled
- [ ] Run unit/integration/application tests on device
- [ ] Add documentation
- [ ] Add to CHANGELOG.md after merging (add links to docs and issues)