### PR TITLE
Assign proper interrupt handler function names to Core's i2c_hal.c

### DIFF
--- a/hal/src/core/i2c_hal.c
+++ b/hal/src/core/i2c_hal.c
@@ -569,7 +569,7 @@ static void HAL_I2C_ER_InterruptHandler(HAL_I2C_Interface i2c)
  * @param  None
  * @retval None
  */
-void I2C1_ER_irq(void)
+void HAL_I2C1_ER_Handler(void)
 {
     HAL_I2C_ER_InterruptHandler(HAL_I2C_INTERFACE1);
 }
@@ -645,7 +645,7 @@ static void HAL_I2C_EV_InterruptHandler(HAL_I2C_Interface i2c)
  * @param  None
  * @retval None
  */
-void I2C1_EV_irq(void)
+void HAL_I2C1_EV_Handler(void)
 {
     HAL_I2C_EV_InterruptHandler(HAL_I2C_INTERFACE1);
 }


### PR DESCRIPTION
### Problem

Using a core in I2C slave mode would cause a hard reset on pulling D0/I2C_SCL Low.

### Cause

Improperly named function for I2C events and Errors.

### Solution

Properly assign I2C interrupt service handler functions.

### Steps to Test

Enable Wire library as slave. Pull D0 Low;

### Example App

```c
void reqEv(){
    return;
}
void setup() {
  Wire.begin(1);
  Wire.onRequest(reqEv);
}

void loop() {
 // nada needed
}
```

### References

My thread on the problem. 
https://community.particle.io/t/core-i2c-reboots-core/31551 

---
### Other thoughts.
This will probably fix quite a bit of I2C compatibility on the core as error handling of the peripheral will actually be functional now. 
Bug was introduced in this commit https://github.com/spark/firmware/commit/cec9ade184a1fe9a8dc1a2e5bc4aa60709e2977e
### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [X] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [X] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
