### PR TITLE
Use the device ID as the USB serial number for Core

### DIFF
--- a/bootloader/src/core/usb_desc.h
+++ b/bootloader/src/core/usb_desc.h
@@ -42,7 +42,7 @@
 #define DFU_SIZ_STRING_LANGID           4
 #define DFU_SIZ_STRING_VENDOR           38
 #define DFU_SIZ_STRING_PRODUCT          20
-#define DFU_SIZ_STRING_SERIAL           26
+#define DFU_SIZ_STRING_SERIAL           52
 #define DFU_SIZ_STRING_INTERFACE0       98		/* Flash Bank 0 */
 #define DFU_SIZ_STRING_INTERFACE1       98		/* SPI Flash */
 

--- a/platform/MCU/STM32F1xx/SPARK_Firmware_Driver/inc/usb_desc.h
+++ b/platform/MCU/STM32F1xx/SPARK_Firmware_Driver/inc/usb_desc.h
@@ -64,7 +64,7 @@
 #define USB_SIZ_STRING_LANGID                   4
 #define USB_SIZ_STRING_VENDOR                   38
 #define USB_SIZ_STRING_PRODUCT                  50
-#define USB_SIZ_STRING_SERIAL                   26
+#define USB_SIZ_STRING_SERIAL                   52
 
 #define STANDARD_ENDPOINT_DESC_SIZE             0x09
 


### PR DESCRIPTION
### Problem

When connecting a Core to USB, the serial number reported is a strange number instead of the device ID. The Photon and Electron report their device ID.

```
$ lsusb -v | grep Particle -A 2
  iManufacturer           1 Particle          
  iProduct                2 Spark Core with WiFi    
  iSerial                 3 6D75569D4957
```

This is blocking the CLI from using the USB serial number to detect the device ID of any connected device.

### Solution

Port USB serial number code from Photon/Electron to Core.

Note: DFU mode still reports the original serial number instead of the device ID. I'm not sure how to recompile and flash the piece of software that contains DFU to a Core. It would be good to update in the long run, but it's not crucial to do it right away.

### Steps to Test

Connect Core to USB, flash system firmware from PR.

```
$ lsusb -v | grep Particle -A 2
  iManufacturer           1 Particle          
  iProduct                2 Spark Core with WiFi    
  iSerial                 3 54FF72011111111111111111
```

### Completeness

- [X] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
