### PR TITLE
Fixed shadowing of write(const unint_8_t*, sizte_t) in USBKeyboard

### DIFF
--- a/wiring/inc/spark_wiring_usbkeyboard.h
+++ b/wiring/inc/spark_wiring_usbkeyboard.h
@@ -20,7 +20,7 @@
 
   You should have received a copy of the GNU Lesser General Public
   License along with this library; if not, see <http://www.gnu.org/licenses/>.
-  ******************************************************************************
+ ******************************************************************************
  */
 
 #ifndef __SPARK_WIRING_USBKEYBOARD_H
@@ -34,31 +34,34 @@
 
 typedef struct
 {
-  uint8_t reportId; // 0x02
-	uint8_t modifiers;
-	uint8_t reserved;
-	uint8_t keys[6];
+    uint8_t reportId; // 0x02
+    uint8_t modifiers;
+    uint8_t reserved;
+    uint8_t keys[6];
 } KeyReport;
 
 class USBKeyboard : public Print
 {
 private:
-	KeyReport keyReport;
+    KeyReport keyReport;
 
 public:
-	USBKeyboard(void);
+    USBKeyboard(void);
 
-	void begin(void);
-	void end(void);
-  virtual size_t write(uint8_t ch);
-	virtual size_t writeKey(uint16_t k, uint16_t modifiers = 0);
-  virtual size_t click(uint16_t k, uint16_t modifiers = 0);
-	virtual size_t press(uint16_t k, uint16_t modifiers = 0);
-	virtual size_t release(uint16_t k, uint16_t modifiers = 0);
-	virtual void releaseAll(void);
+    void begin(void);
+    void end(void);
+    virtual size_t write(uint8_t ch);
+    virtual size_t write(const uint8_t *buffer, size_t size){
+        return Print::write(buffer, size);
+    }
+    virtual size_t writeKey(uint16_t k, uint16_t modifiers = 0);
+    virtual size_t click(uint16_t k, uint16_t modifiers = 0);
+    virtual size_t press(uint16_t k, uint16_t modifiers = 0);
+    virtual size_t release(uint16_t k, uint16_t modifiers = 0);
+    virtual void releaseAll(void);
 
 private:
-  void sendReport();
+    void sendReport();
 };
 
 extern USBKeyboard& _fetch_usbkeyboard();

--- a/wiring/inc/spark_wiring_usbkeyboard.h
+++ b/wiring/inc/spark_wiring_usbkeyboard.h
@@ -50,10 +50,10 @@ public:
 
     void begin(void);
     void end(void);
+
+    using Print::write;
     virtual size_t write(uint8_t ch);
-    virtual size_t write(const uint8_t *buffer, size_t size){
-        return Print::write(buffer, size);
-    }
+
     virtual size_t writeKey(uint16_t k, uint16_t modifiers = 0);
     virtual size_t click(uint16_t k, uint16_t modifiers = 0);
     virtual size_t press(uint16_t k, uint16_t modifiers = 0);


### PR DESCRIPTION
### Problem

The USBKeyboard class inherits from Print and reimplements virtual function `write(uint8_t ch)`.
It does not re-implement `write(const uint8_t *buffer, size_t size)`.

This results in a compiler warning about the second function being shadowed:

```
In file included from ../wiring/inc/spark_wiring_string.h:34:0,
                 from ../wiring/inc/spark_wiring_stream.h:30,
                 from ../wiring/inc/spark_wiring.h:38,
                 from ./inc/application.h:40,
                 from /home/elco/repos/firmware/platform/spark/modules/Platform.h:4,
                 from /home/elco/repos/firmware/lib/src/DS2408.cpp:8:
../wiring/inc/spark_wiring_print.h:67:20: warning: 'virtual size_t Print::write(const uint8_t*, size_t)' was hidden [-Woverloaded-virtual]
     virtual size_t write(const uint8_t *buffer, size_t size);
                    ^
In file included from ./inc/application.h:51:0,
                 from /home/elco/repos/firmware/platform/spark/modules/Platform.h:4,
                 from /home/elco/repos/firmware/lib/src/DS2408.cpp:8:
../wiring/inc/spark_wiring_usbkeyboard.h:53:20: warning:   by 'virtual size_t USBKeyboard::write(uint8_t)' [-Woverloaded-virtual]
     virtual size_t write(uint8_t ch);
                    ^
```

### Solution
Include both functions signatures and just delegate to Print:
```
    virtual size_t write(uint8_t ch);
    virtual size_t write(const uint8_t *buffer, size_t size){
        return Print::write(buffer, size);
    }
```
Or even simpler:
```
    using Print::write;
    virtual size_t write(uint8_t ch);
```


The file was a mix of spaces and tabs. I converted all tabs to 4 spaces.
I am not using the USBKeyboard class. I just want to get rid of the many compiler warnings.
I should probably just write a custom application.h file.

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
