### PR TITLE
wiring++

### DIFF
--- a/hal/inc/pinmap_defs.h
+++ b/hal/inc/pinmap_defs.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+
+/* Exported types ------------------------------------------------------------*/
+
+typedef uint16_t pin_t;
+
+typedef enum PinMode {
+  INPUT,
+  OUTPUT,
+  INPUT_PULLUP,
+  INPUT_PULLDOWN,
+  AF_OUTPUT_PUSHPULL, //Used internally for Alternate Function Output PushPull(TIM, UART, SPI etc)
+  AF_OUTPUT_DRAIN,    //Used internally for Alternate Function Output Drain(I2C etc). External pullup resistors required.
+  AN_INPUT,           //Used internally for ADC Input
+  AN_OUTPUT,          //Used internally for DAC Output
+  PIN_MODE_NONE=0xFF
+} PinMode;
+
+typedef enum {
+    PF_NONE,
+    PF_DIO,
+    PF_TIMER,
+    PF_ADC,
+  PF_DAC
+} PinFunction;
+
+
+
+#ifdef __cplusplus
+
+namespace particle { namespace pin {
+
+#define PIN_COUNT(name, count) \
+	const int name = count;
+
+template<pin_t PIN> class AbstractPin {
+public:
+	const pin_t pin = PIN;
+};
+
+template<pin_t PIN> class GPIOPin : public AbstractPin<PIN> {
+public:
+	const pin_t pin = PIN;
+
+	PinMode mode() const;
+	void mode(PinMode mode);
+
+	operator pin_t() const { return pin; }
+
+};
+
+extern "C" void digitalWrite(uint16_t pin, uint8_t value);
+extern "C" int32_t digitalRead(uint16_t pin);
+
+template<pin_t PIN> class DigitalPin : public GPIOPin<PIN> {
+public:
+	bool read() { return digitalRead(PIN)!=0; }
+	void write(bool value) { digitalWrite(PIN, value ? 1 : 0); }
+
+	bool isHigh() { return read(); }
+	bool isLow() { return read(); }
+
+	DigitalPin& operator =(bool value) { write(value); return *this; }
+};
+
+}}  // particle::pin
+
+#endif

--- a/hal/inc/pinmap_hal.h
+++ b/hal/inc/pinmap_hal.h
@@ -27,6 +27,8 @@
 #ifndef __PINMAP_HAL_H
 #define __PINMAP_HAL_H
 
+#include "pinmap_defs.h"
+
 /* Includes ------------------------------------------------------------------*/
 #include <stdbool.h>
 #include <stdint.h>
@@ -34,30 +36,6 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/* Exported types ------------------------------------------------------------*/
-
-typedef uint16_t pin_t;
-
-typedef enum PinMode {
-  INPUT,
-  OUTPUT,
-  INPUT_PULLUP,
-  INPUT_PULLDOWN,
-  AF_OUTPUT_PUSHPULL, //Used internally for Alternate Function Output PushPull(TIM, UART, SPI etc)
-  AF_OUTPUT_DRAIN,    //Used internally for Alternate Function Output Drain(I2C etc). External pullup resistors required.
-  AN_INPUT,           //Used internally for ADC Input
-  AN_OUTPUT,          //Used internally for DAC Output
-  PIN_MODE_NONE=0xFF
-} PinMode;
-
-typedef enum {
-    PF_NONE,
-    PF_DIO,
-    PF_TIMER,
-    PF_ADC,
-  PF_DAC
-} PinFunction;
 
 PinFunction HAL_Validate_Pin_Function(pin_t pin, PinFunction pinFunction);
 
@@ -94,6 +72,7 @@ STM32_Pin_Info* HAL_Pin_Map(void);
 #endif
 #define FIRST_ANALOG_PIN 10
 
+#ifndef __cplusplus
 #define D0 0
 #define D1 1
 #define D2 2
@@ -102,6 +81,17 @@ STM32_Pin_Info* HAL_Pin_Map(void);
 #define D5 5
 #define D6 6
 #define D7 7
+#else
+extern class pinD0_t : public particle::pin::DigitalPin<0>{} D0;
+extern class pinD1_t : public particle::pin::DigitalPin<1>{} D1;
+extern class pinD2_t : public particle::pin::DigitalPin<2>{} D2;
+extern class pinD3_t : public particle::pin::DigitalPin<3>{} D3;
+extern class pinD4_t : public particle::pin::DigitalPin<4>{} D4;
+extern class pinD5_t : public particle::pin::DigitalPin<5>{} D5;
+extern class pinD6_t : public particle::pin::DigitalPin<6>{} D6;
+extern class pinD7_t : public particle::pin::DigitalPin<7>{} D7;
+
+#endif
 
 // todo - this is corev1 specific, needs to go in a conditional define
 

--- a/hal/src/stm32f2xx/platform_headers.h
+++ b/hal/src/stm32f2xx/platform_headers.h
@@ -8,10 +8,6 @@
 #ifndef PLATFORM_HEADERS_H
 #define	PLATFORM_HEADERS_H
 
-#ifdef	__cplusplus
-extern "C" {
-#endif
-
 // These headers contain platform-specific defines.
 #include "gpio_hal.h"
 #include "hw_config.h"
@@ -21,10 +17,6 @@ extern "C" {
 #include "modem/enums_hal.h"
 #endif
 #include "usb_settings.h"
-
-#ifdef	__cplusplus
-}
-#endif
 
 #endif	/* PLATFORM_HEADERS_H */
 

--- a/user/tests/wiring/api/pin.cpp
+++ b/user/tests/wiring/api/pin.cpp
@@ -1,0 +1,14 @@
+#include "testapi.h"
+#include "Particle.h"
+
+test(Pin_digital_methods)
+{
+	bool value;
+    API_COMPILE(value=D0.read());
+    API_COMPILE(D0.write(HIGH));
+}
+
+test(Pin_digital_conversion_to_primitive) {
+	API_COMPILE(digitalWrite(D0, HIGH));
+	API_COMPILE(digitalRead(D0));
+}

--- a/wiring_globals/src/spark_wiring_gpio.cpp
+++ b/wiring_globals/src/spark_wiring_gpio.cpp
@@ -34,6 +34,7 @@
 #include "delay_hal.h"
 #include "pinmap_hal.h"
 #include "system_task.h"
+#include "pinmap_hal.h"
 
 /*
  * @brief Set the mode of the pin to OUTPUT, INPUT, INPUT_PULLUP,
@@ -332,3 +333,14 @@ uint32_t pulseIn(pin_t pin, uint16_t value) {
 void setDACBufferred(pin_t pin, uint8_t state) {
   HAL_DAC_Enable_Buffer(pin, state);
 }
+
+
+pinD0_t D0;
+pinD1_t D1;
+pinD2_t D2;
+pinD3_t D3;
+pinD4_t D4;
+pinD5_t D5;
+pinD6_t D6;
+pinD7_t D7;
+


### PR DESCRIPTION
adds a PoC for pin objects, so you can write

```
if (D0.read()) {   
  D1.write(LOW);
}
```

We might later extend to allow direct conversion and assignment, e.g.

```
if (D0) {
    D1 = HIGH;
}
```

Having objects as pins allows for many possibilities, including traits - preventing a pin from being used in a way that is not compatible with that pin. 