### PR TITLE
Fixes incorrect handling of inet_gethostbyname() return values in Cellular.resolve() and WiFi.resolve()

### DIFF
--- a/user/tests/wiring/no_fixture/cellular.cpp
+++ b/user/tests/wiring/no_fixture/cellular.cpp
@@ -113,6 +113,12 @@ test(CELLULAR_05_resolve) {
     checkIPAddress("www.google.com", Cellular.resolve("www.google.com"));
 }
 
+test(CELLULAR_06_resolve) {
+    connect_to_cloud(6*60*1000);
+    IPAddress addr = Cellular.resolve("this.is.not.a.real.host");
+    assertEqual(addr, 0);
+}
+
 int how_many_band_options_are_available(void)
 {
     CellularBand band_avail;

--- a/user/tests/wiring/no_fixture/wifi.cpp
+++ b/user/tests/wiring/no_fixture/wifi.cpp
@@ -25,7 +25,7 @@
 test(WIFI_01_resolve_3_levels)
 {
     IPAddress address = WiFi.resolve("pool.ntp.org");
-    assertNotEqual(address[0], 0);
+    assertNotEqual(address, 0);
 
     // ensure the version field is set
     assertNotEqual(address.version(), 0);
@@ -37,7 +37,12 @@ test(WIFI_01_resolve_3_levels)
 test(WIFI_02_resolve_4_levels)
 {
     IPAddress address = WiFi.resolve("north-america.pool.ntp.org");
-    assertNotEqual(address[0], 0);
+    assertNotEqual(address, 0);
+}
+
+test(WIFI_03_resolve) {
+    IPAddress addr = WiFi.resolve("this.is.not.a.real.host");
+    assertEqual(addr, 0);
 }
 
 void checkIPAddress(const char* name, const IPAddress& address)
@@ -61,7 +66,7 @@ void checkEtherAddress(const uint8_t* address)
     assertNotEqual(sum, 0);
 }
 
-test(WIFI_03_config)
+test(WIFI_04_config)
 {
     checkIPAddress("local", WiFi.localIP());
 
@@ -90,14 +95,14 @@ test(WIFI_03_config)
     assertTrue(!memcmp(ether, ether2, 6))
 }
 
-test(WIFI_04_scan)
+test(WIFI_05_scan)
 {
     spark::Vector<WiFiAccessPoint> aps(20);
     int apsFound = WiFi.scan(aps.data(), 20);
     assertMoreOrEqual(apsFound, 1);
 }
 
-test(WIFI_05_reconnections_that_use_wlan_restart_dont_cause_memory_leaks)
+test(WIFI_06_reconnections_that_use_wlan_restart_dont_cause_memory_leaks)
 {
 #if (PLATFORM_ID == 6 || PLATFORM_ID == 8) && (PLATFORM_THREADING == 1 && USE_THREADING == 1)
     /* This test should only be run with threading disabled */
@@ -157,7 +162,7 @@ test(WIFI_05_reconnections_that_use_wlan_restart_dont_cause_memory_leaks)
 #endif
 }
 
-test(WIFI_06_restore_connection)
+test(WIFI_07_restore_connection)
 {
     set_system_mode(AUTOMATIC);
     if (!Particle.connected())
@@ -168,33 +173,33 @@ test(WIFI_06_restore_connection)
 
 #if PLATFORM_ID == 6 || PLATFORM_ID == 8
 
-test(WIFI_07_reset_hostname)
+test(WIFI_08_reset_hostname)
 {
     assertEqual(WiFi.setHostname(NULL), 0);
 }
 
-test(WIFI_08_default_hostname_equals_device_id)
+test(WIFI_09_default_hostname_equals_device_id)
 {
     String hostname = WiFi.hostname();
     String devId = System.deviceID();
     assertEqual(hostname, devId);
 }
 
-test(WIFI_09_custom_hostname_can_be_set)
+test(WIFI_10_custom_hostname_can_be_set)
 {
     String hostname("testhostname");
     assertEqual(WiFi.setHostname(hostname), 0);
     assertEqual(WiFi.hostname(), hostname);
 }
 
-test(WIFI_10_restore_default_hostname)
+test(WIFI_11_restore_default_hostname)
 {
     assertEqual(WiFi.setHostname(NULL), 0);
 }
 
 #endif // PLATFORM_ID == 6 || PLATFORM_ID == 8
 
-test(WIFI_11_scan_returns_zero_result_or_error_when_wifi_is_off)
+test(WIFI_12_scan_returns_zero_result_or_error_when_wifi_is_off)
 {
     WiFiAccessPoint results[5];
     WiFi.off();
@@ -207,7 +212,7 @@ test(WIFI_11_scan_returns_zero_result_or_error_when_wifi_is_off)
     assertLessOrEqual(WiFi.scan(results, 5), 0);
 }
 
-test(WIFI_12_restore_connection)
+test(WIFI_13_restore_connection)
 {
     if (!Particle.connected())
     {

--- a/user/tests/wiring/wifi/wlan.cpp
+++ b/user/tests/wiring/wifi/wlan.cpp
@@ -14,7 +14,7 @@ test(WLAN_Test1_Lookup_IP_From_Hostname)
     HAL_IPAddress addr = { 0 };
     int result = inet_gethostbyname(hostname, strlen(hostname), &addr, 0 /* nif */, nullptr);
     assertEqual(addr.ipv4, spark_io);
-    assertMoreOrEqual(result, 0); // cc3000 returns >=0 on success
+    assertEqual(result, 0); // inet_gethostbyname returns 0 on success
 }
 
 test(WLAN_Test2_Ping_To_Symmetrical_Address)

--- a/wiring/inc/spark_wiring_cellular.h
+++ b/wiring/inc/spark_wiring_cellular.h
@@ -128,7 +128,7 @@ public:
 
     IPAddress resolve(const char* name)
     {
-        HAL_IPAddress ip;
+        HAL_IPAddress ip = {0};
         return (inet_gethostbyname(name, strlen(name), &ip, *this, NULL) != 0) ?
                 IPAddress(uint32_t(0)) : IPAddress(ip);
     }

--- a/wiring/inc/spark_wiring_cellular.h
+++ b/wiring/inc/spark_wiring_cellular.h
@@ -129,7 +129,7 @@ public:
     IPAddress resolve(const char* name)
     {
         HAL_IPAddress ip;
-        return (inet_gethostbyname(name, strlen(name), &ip, *this, NULL)<0) ?
+        return (inet_gethostbyname(name, strlen(name), &ip, *this, NULL) != 0) ?
                 IPAddress(uint32_t(0)) : IPAddress(ip);
     }
 };

--- a/wiring/inc/spark_wiring_wifi.h
+++ b/wiring/inc/spark_wiring_wifi.h
@@ -200,7 +200,7 @@ public:
 
     IPAddress resolve(const char* name)
     {
-        HAL_IPAddress ip;
+        HAL_IPAddress ip = {0};
         return (inet_gethostbyname(name, strlen(name), &ip, *this, NULL) != 0) ?
                 IPAddress(uint32_t(0)) : IPAddress(ip);
     }

--- a/wiring/inc/spark_wiring_wifi.h
+++ b/wiring/inc/spark_wiring_wifi.h
@@ -201,7 +201,7 @@ public:
     IPAddress resolve(const char* name)
     {
         HAL_IPAddress ip;
-        return (inet_gethostbyname(name, strlen(name), &ip, *this, NULL)<0) ?
+        return (inet_gethostbyname(name, strlen(name), &ip, *this, NULL) != 0) ?
                 IPAddress(uint32_t(0)) : IPAddress(ip);
     }
 


### PR DESCRIPTION
### Problem

See issue #1304

`Cellular.resolve()` and `WiFi.resolve()` functions that internally use `inet_gethostbyname()` incorrectly handle `inet_gethostbyname()` return values.

### Solution

- Treat any `inet_gethostbyname()` return value other than `0` as an error.
- Fix tests to check all octets of the IP address, instead of just the first one.

### Steps to Test

- `wiring/no_fixture`
- `wiring/wifi`

### References

- Closes issue #1304
- CH7267

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
