### PR TITLE
Fixes Particle.connect() behavior in SEMI_AUTOMATIC mode

### DIFF
--- a/system/src/main.cpp
+++ b/system/src/main.cpp
@@ -407,6 +407,10 @@ void manage_safe_mode()
     }
 }
 
+bool semi_automatic_connecting(bool threaded) {
+    return system_mode() == SEMI_AUTOMATIC && !threaded && spark_cloud_flag_auto_connect() && !spark_cloud_flag_connected();
+}
+
 void app_loop(bool threaded)
 {
     DECLARE_SYS_HEALTH(ENTERED_WLAN_Loop);
@@ -414,33 +418,42 @@ void app_loop(bool threaded)
         Spark_Idle();
 
     static uint8_t SPARK_WIRING_APPLICATION = 0;
-    if(threaded || SPARK_WLAN_SLEEP || !spark_cloud_flag_auto_connect() || spark_cloud_flag_connected() || SPARK_WIRING_APPLICATION || (system_mode()!=AUTOMATIC))
-    {
-        if(threaded || !SPARK_FLASH_UPDATE)
+    do {
+        if(threaded || SPARK_WLAN_SLEEP || !spark_cloud_flag_auto_connect() || spark_cloud_flag_connected() || SPARK_WIRING_APPLICATION || (system_mode()!=AUTOMATIC))
         {
-            if ((SPARK_WIRING_APPLICATION != 1))
+            if(threaded || !SPARK_FLASH_UPDATE)
             {
-                //Execute user application setup only once
-                DECLARE_SYS_HEALTH(ENTERED_Setup);
-                if (system_mode()!=SAFE_MODE)
-                 setup();
-                SPARK_WIRING_APPLICATION = 1;
-#if !(defined(MODULAR_FIRMWARE) && MODULAR_FIRMWARE)
-                _post_loop();
-#endif
-            }
+                if (semi_automatic_connecting(threaded)) {
+                    break;
+                }
 
-            //Execute user application loop
-            DECLARE_SYS_HEALTH(ENTERED_Loop);
-            if (system_mode()!=SAFE_MODE) {
-                loop();
-                DECLARE_SYS_HEALTH(RAN_Loop);
+                if ((SPARK_WIRING_APPLICATION != 1))
+                {
+                    //Execute user application setup only once
+                    DECLARE_SYS_HEALTH(ENTERED_Setup);
+                    if (system_mode()!=SAFE_MODE)
+                     setup();
+                    SPARK_WIRING_APPLICATION = 1;
 #if !(defined(MODULAR_FIRMWARE) && MODULAR_FIRMWARE)
-                _post_loop();
+                    _post_loop();
 #endif
+                    if (semi_automatic_connecting(threaded)) {
+                        break;
+                    }
+                }
+
+                //Execute user application loop
+                DECLARE_SYS_HEALTH(ENTERED_Loop);
+                if (system_mode()!=SAFE_MODE) {
+                    loop();
+                    DECLARE_SYS_HEALTH(RAN_Loop);
+#if !(defined(MODULAR_FIRMWARE) && MODULAR_FIRMWARE)
+                    _post_loop();
+#endif
+                }
             }
         }
-    }
+    } while(false);
 #if PLATFORM_ID == 3 && SUSPEND_APPLICATION_THREAD_LOOP_COUNT
     // Suspend thread execution for some minimum time on every Nth loop iteration in order to workaround
     // 100% CPU usage on the virtual device platform

--- a/user/tests/app/particle_connect_semi_automatic_issue_1399/test.cpp
+++ b/user/tests/app/particle_connect_semi_automatic_issue_1399/test.cpp
@@ -1,0 +1,84 @@
+#include "application.h"
+
+SYSTEM_MODE(SEMI_AUTOMATIC);
+SYSTEM_THREAD(DISABLED);
+
+LOG_SOURCE_CATEGORY("test")
+
+namespace {
+
+SerialLogHandler logHandler(LOG_LEVEL_NONE, {
+    { "test", LOG_LEVEL_ALL }
+});
+
+static bool loopExecuted = false;
+static bool testFinished = false;
+
+static void fail() {
+    testFinished = true;
+    RGB.control(true);
+    RGB.color(0xff0000); // Red
+    LOG(ERROR, "TEST FAILED");
+}
+
+static void pass() {
+    testFinished = true;
+    RGB.control(true);
+    RGB.color(0x00ff00); // Green
+    LOG(INFO, "TEST SUCCEEDED");
+}
+
+} // namespace
+
+void setup() {
+    waitUntil(Serial.isConnected);
+
+    LOG(INFO, "Test started");
+    LOG(INFO, "Connecting to WiFi network");
+    WiFi.on();
+    WiFi.connect();
+    waitUntil(WiFi.ready);
+    LOG(INFO, "Connected to WiFi network");
+
+    LOG(INFO, "Connecting to the cloud");
+    Particle.connect();
+    if (Particle.connected()) {
+        fail();
+    }
+}
+
+void loop() {
+    if (testFinished) {
+        return;
+    }
+
+    if (!loopExecuted) {
+        loopExecuted = true;
+
+        // First time the loop is running. We should be connected to the cloud
+        if (!Particle.connected()) {
+            fail();
+            return;
+        }
+
+        LOG(INFO, "Connected to the cloud");
+
+        // Disconnect from the cloud
+        LOG(INFO, "Disconnecting from the cloud");
+        Particle.disconnect();
+        waitUntil(Particle.disconnected);
+        LOG(INFO, "Disconnected from the cloud");
+
+        LOG(INFO, "Connecting to the cloud");
+        Particle.connect();
+    } else {
+        // Second time the loop is running, we should also be connected to the cloud again
+        if (!Particle.connected()) {
+            fail();
+            return;
+        }
+        LOG(INFO, "Connected to the cloud");
+
+        pass();
+    }
+}

--- a/user/tests/wiring/no_fixture/cloud.cpp
+++ b/user/tests/wiring/no_fixture/cloud.cpp
@@ -1,36 +1,13 @@
 #include "application.h"
 #include "unit-test/unit-test.h"
 
-test(CLOUD_01_Particle_Connect_Blocks_In_SemiAutomatic_Mode_With_Threading_Disabled) {
-    if (system_thread_get_state(nullptr) == spark::feature::ENABLED) {
-        skip();
-        return;
-    }
-
+test(CLOUD_01_Particle_Connect_Does_Not_Block_In_SemiAutomatic_Mode) {
     Particle.disconnect();
     waitFor(Particle.disconnected, 10000);
     assertTrue(Particle.disconnected());
-    
+
     // Switch to SEMI_AUTOMATIC mode
     set_system_mode(SEMI_AUTOMATIC);
-
-    Particle.connect();
-    assertTrue(Particle.connected());
-}
-
-test(CLOUD_02_Particle_Connect_Does_Not_Block_In_SemiAutomatic_Mode_With_Threading_Enabled) {
-    if (system_thread_get_state(nullptr) == spark::feature::DISABLED) {
-        skip();
-        return;
-    }
-    Particle.disconnect();
-    waitFor(Particle.disconnected, 10000);
-    assertTrue(Particle.disconnected());
-    
-    // Switch to SEMI_AUTOMATIC mode
-    set_system_mode(SEMI_AUTOMATIC);
-
-    assertTrue(system_thread_get_state(nullptr) == spark::feature::ENABLED);
 
     Particle.connect();
     assertFalse(Particle.connected());

--- a/wiring/inc/spark_wiring_cloud.h
+++ b/wiring/inc/spark_wiring_cloud.h
@@ -325,12 +325,6 @@ public:
     static bool disconnected(void) { return !connected(); }
     static void connect(void) {
         spark_cloud_flag_connect();
-        if (system_thread_get_state(nullptr)==spark::feature::DISABLED &&
-            SystemClass::mode() == SEMI_AUTOMATIC)
-        {
-            // Particle.connect() should be blocking in SEMI_AUTOMATIC mode when threading is disabled
-            waitUntil(connected);
-        }
     }
     static void disconnect(void) { spark_cloud_flag_disconnect(); }
     static void process(void) {


### PR DESCRIPTION
<details>
  <summary><i>submission notes</i></summary>

```
**Important:** Please sanitize/remove any confidential info like usernames, passwords, org names, product names/ids, access tokens, client ids/secrets, or anything else you don't wish to share.

Please Read and Sign the Contributor License Agreement ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md)).

You may also delete this submission notes header if you'd like. Thank you for contributing!
```
</details>

### Problem

`Particle.connect()` still does not work correctly in `SEMI_AUTOMATIC` mode. Original issues: #973 #1399 

### Solution

Instead of blocking `Particle.connect()` call immediately as implemented in #1145, only the next invocation of `loop()` should be blocked until the device connects to the cloud.

### Steps to Test

- `app/particle_connect_semi_automatic_issue_1399`

### Example App

N/A

### References

- [CH8403]
- #973
- Closes #1399
- #1145

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
