### PR TITLE
Disable WKP pin waking device up from SLEEP_MODE_DEEP

### DIFF
--- a/hal/inc/core_hal.h
+++ b/hal/inc/core_hal.h
@@ -136,13 +136,19 @@ int HAL_Core_Get_Last_Reset_Info(int *reason, uint32_t *data, void *reserved);
  */
 void HAL_Notify_Button_State(uint8_t button, uint8_t state);
 
+typedef enum {
+    HAL_STANDBY_MODE_FLAG_NONE = 0,
+    HAL_STANDBY_MODE_FLAG_DISABLE_WKP_PIN = 1
+} hal_standby_mode_flag_t;
+
 void HAL_Core_Enter_Safe_Mode(void* reserved);
 void HAL_Core_Enter_Bootloader(bool persist);
 void HAL_Core_Enter_Stop_Mode(uint16_t wakeUpPin, uint16_t edgeTriggerMode, long seconds);
 int32_t HAL_Core_Enter_Stop_Mode_Ext(const uint16_t* pins, size_t pins_count, const InterruptMode* mode, size_t mode_count, long seconds, void* reserved);
 void HAL_Core_Execute_Stop_Mode(void);
-void HAL_Core_Enter_Standby_Mode(uint32_t seconds, void* reserved);
+void HAL_Core_Enter_Standby_Mode(uint32_t seconds, uint32_t flags);
 void HAL_Core_Execute_Standby_Mode(void);
+void HAL_Core_Execute_Standby_Mode_Ext(uint32_t flags, void* reserved);
 uint32_t HAL_Core_Compute_CRC32(const uint8_t *pBuffer, uint32_t bufferSize);
 
 typedef enum _BootloaderFlag_t {

--- a/hal/inc/hal_dynalib_core.h
+++ b/hal/inc/hal_dynalib_core.h
@@ -51,7 +51,7 @@ DYNALIB_FN(6, hal_core, HAL_Core_Factory_Reset, void(void))
 DYNALIB_FN(7, hal_core, HAL_Core_Enter_Bootloader, void(bool))
 DYNALIB_FN(8, hal_core, HAL_Core_Enter_Stop_Mode, void(uint16_t, uint16_t, long))
 DYNALIB_FN(9, hal_core, HAL_Core_Execute_Stop_Mode, void(void))
-DYNALIB_FN(10, hal_core, HAL_Core_Enter_Standby_Mode, void(uint32_t, void*))
+DYNALIB_FN(10, hal_core, HAL_Core_Enter_Standby_Mode, void(uint32_t, uint32_t))
 DYNALIB_FN(11, hal_core, HAL_Core_Execute_Standby_Mode, void(void))
 DYNALIB_FN(12, hal_core, HAL_Core_Compute_CRC32, uint32_t(const uint8_t*, uint32_t))
 DYNALIB_FN(13, hal_core, HAL_device_ID, unsigned(uint8_t*, unsigned))
@@ -77,6 +77,7 @@ DYNALIB_FN(31, hal_core, HAL_Core_Led_Mirror_Pin_Disable, void(uint8_t, uint8_t,
 
 DYNALIB_FN(32, hal_core, HAL_Set_Event_Callback, void(HAL_Event_Callback, void*))
 DYNALIB_FN(33, hal_core, HAL_Core_Enter_Stop_Mode_Ext, int32_t(const uint16_t*, size_t, const InterruptMode*, size_t, long, void*))
+DYNALIB_FN(34, hal_core, HAL_Core_Execute_Standby_Mode_Ext, void(uint32_t, void*))
 
 DYNALIB_END(hal_core)
 

--- a/hal/src/core/core_hal.c
+++ b/hal/src/core/core_hal.c
@@ -386,7 +386,7 @@ void HAL_Core_Execute_Stop_Mode(void)
     HAL_enable_irq(state);
 }
 
-void HAL_Core_Enter_Standby_Mode(uint32_t seconds, void* reserved)
+void HAL_Core_Enter_Standby_Mode(uint32_t seconds, uint32_t flags)
 {
     // Configure RTC wake-up
     if (seconds > 0) {

--- a/hal/src/gcc/core_hal.cpp
+++ b/hal/src/gcc/core_hal.cpp
@@ -244,7 +244,7 @@ int32_t HAL_Core_Enter_Stop_Mode_Ext(const uint16_t* pins, size_t pins_count, co
     return -1;
 }
 
-void HAL_Core_Enter_Standby_Mode(uint32_t seconds, void* reserved)
+void HAL_Core_Enter_Standby_Mode(uint32_t seconds, uint32_t flags)
 {
     MSG("Standby mode not implemented.");
 }

--- a/hal/src/stm32f2xx/core_hal_stm32f2xx.c
+++ b/hal/src/stm32f2xx/core_hal_stm32f2xx.c
@@ -769,7 +769,7 @@ void HAL_Core_Execute_Stop_Mode(void)
     while(RCC_GetSYSCLKSource() != 0x08);
 }
 
-void HAL_Core_Enter_Standby_Mode(uint32_t seconds, void* reserved)
+void HAL_Core_Enter_Standby_Mode(uint32_t seconds, uint32_t flags)
 {
     // Configure RTC wake-up
     if (seconds > 0) {
@@ -777,19 +777,29 @@ void HAL_Core_Enter_Standby_Mode(uint32_t seconds, void* reserved)
         HAL_RTC_Set_UnixAlarm((time_t) seconds);
     }
 
-    HAL_Core_Execute_Standby_Mode();
+    HAL_Core_Execute_Standby_Mode_Ext(flags, NULL);
 }
 
-void HAL_Core_Execute_Standby_Mode(void)
+void HAL_Core_Execute_Standby_Mode_Ext(uint32_t flags, void* reserved)
 {
-    /* Enable WKUP pin */
-    PWR_WakeUpPinCmd(ENABLE);
+    if ((flags & HAL_STANDBY_MODE_FLAG_DISABLE_WKP_PIN) == 0) {
+        /* Enable WKUP pin */
+        PWR_WakeUpPinCmd(ENABLE);
+    } else {
+        /* Disable WKUP pin */
+        PWR_WakeUpPinCmd(DISABLE);
+    }
 
     /* Request to enter STANDBY mode */
     PWR_EnterSTANDBYMode();
 
     /* Following code will not be reached */
     while(1);
+}
+
+void HAL_Core_Execute_Standby_Mode(void)
+{
+    HAL_Core_Execute_Standby_Mode_Ext(0, NULL);
 }
 
 /**

--- a/hal/src/template/core_hal.cpp
+++ b/hal/src/template/core_hal.cpp
@@ -83,7 +83,7 @@ void HAL_Core_Execute_Stop_Mode(void)
 {
 }
 
-void HAL_Core_Enter_Standby_Mode(uint32_t seconds, void* reserved)
+void HAL_Core_Enter_Standby_Mode(uint32_t seconds, uint32_t flags)
 {
 }
 

--- a/system/inc/system_sleep.h
+++ b/system/inc/system_sleep.h
@@ -33,10 +33,11 @@ typedef enum
     SLEEP_MODE_WLAN = 0, SLEEP_MODE_DEEP = 1, SLEEP_MODE_SOFTPOWEROFF = 2
 } Spark_Sleep_TypeDef;
 
-enum class SystemSleepNetwork
+enum class SystemSleepOption
 {
-    Off,
-    Standby,
+    NetworkOff = 0x00,
+    NetworkStandby = 0x01,
+    DisableWkpPin = 0x02
 };
 
 /**

--- a/system/src/system_sleep.cpp
+++ b/system/src/system_sleep.cpp
@@ -94,9 +94,7 @@ void sleep_fuel_gauge()
 
 bool network_sleep_flag(uint32_t flags)
 {
-    static_assert(static_cast<int>(SystemSleepNetwork::Off)==0, "expected SystemSleepNetwork::Off==0");
-    static_assert(static_cast<int>(SystemSleepNetwork::Standby)==1, "expected SystemSleepNetwork::Standby==1");
-    return (flags & 1)==0;
+    return (flags & SLEEP_NETWORK_STANDBY.value()) == 0;
 }
 
 int system_sleep_impl(Spark_Sleep_TypeDef sleepMode, long seconds, uint32_t param, void* reserved)
@@ -137,8 +135,10 @@ int system_sleep_impl(Spark_Sleep_TypeDef sleepMode, long seconds, uint32_t para
                 network_disconnect(0, NETWORK_DISCONNECT_REASON_SLEEP, NULL);
                 network_off(0, 0, 0, NULL);
             }
+
             system_power_management_sleep();
-            HAL_Core_Enter_Standby_Mode(seconds, nullptr);
+            HAL_Core_Enter_Standby_Mode(seconds,
+                (param & SLEEP_DISABLE_WKP_PIN.value()) ? HAL_STANDBY_MODE_FLAG_DISABLE_WKP_PIN : 0);
             break;
 
 #if Wiring_SetupButtonUX
@@ -147,7 +147,8 @@ int system_sleep_impl(Spark_Sleep_TypeDef sleepMode, long seconds, uint32_t para
             network_off(0, 0, 0, NULL);
             sleep_fuel_gauge();
             system_power_management_sleep();
-            HAL_Core_Enter_Standby_Mode(seconds, nullptr);
+            HAL_Core_Enter_Standby_Mode(seconds,
+                (param & SLEEP_DISABLE_WKP_PIN.value()) ? HAL_STANDBY_MODE_FLAG_DISABLE_WKP_PIN : 0);
             break;
 #endif
     }

--- a/user/tests/wiring/api/system.cpp
+++ b/user/tests/wiring/api/system.cpp
@@ -86,7 +86,7 @@ test(system_sleep)
 
         const pin_t pins_array[] = {D0, D1};
         const InterruptMode mode_array[] = {RISING, FALLING};
-
+    
         /*
          * wakeup pins: pin_t* + size_t
          * trigger mode: single InterruptMode
@@ -107,6 +107,16 @@ test(system_sleep)
         API_COMPILE(System.sleep(pins_array, sizeof(pins_array)/sizeof(*pins_array), mode_array, sizeof(mode_array)/sizeof(*mode_array), 20, SLEEP_NETWORK_STANDBY));
         API_COMPILE(System.sleep(pins_array, sizeof(pins_array)/sizeof(*pins_array), mode_array, sizeof(mode_array)/sizeof(*mode_array), SLEEP_NETWORK_STANDBY, 20));
     }
+
+	// SLEEP_DISABLE_WKP_PIN
+    API_COMPILE(System.sleep(SLEEP_MODE_DEEP, SLEEP_DISABLE_WKP_PIN));
+    API_COMPILE(System.sleep(SLEEP_MODE_DEEP, SLEEP_DISABLE_WKP_PIN, 60));
+    API_COMPILE(System.sleep(SLEEP_MODE_DEEP, 60, SLEEP_DISABLE_WKP_PIN));
+
+    // Flags OR-ing
+    API_COMPILE(System.sleep(SLEEP_MODE_DEEP, SLEEP_DISABLE_WKP_PIN | SLEEP_NETWORK_STANDBY));
+    API_COMPILE(System.sleep(SLEEP_MODE_DEEP, SLEEP_DISABLE_WKP_PIN | SLEEP_NETWORK_STANDBY, 60));
+    API_COMPILE(System.sleep(SLEEP_MODE_DEEP, 60, SLEEP_DISABLE_WKP_PIN | SLEEP_NETWORK_STANDBY));
 }
 
 test(system_mode) {

--- a/wiring/inc/spark_wiring_system.h
+++ b/wiring/inc/spark_wiring_system.h
@@ -36,6 +36,7 @@
 #include "core_hal.h"
 #include "system_user.h"
 #include "system_version.h"
+#include "spark_wiring_flags.h"
 
 #if defined(SPARK_PLATFORM) && PLATFORM_ID!=3
 #define SYSTEM_HW_TICKS 1
@@ -49,25 +50,13 @@
 
 class Stream;
 
-class SleepNetworkFlag
-{
-public:
-    typedef uint8_t flag_t;
-    inline SleepNetworkFlag(SystemSleepNetwork f) : SleepNetworkFlag(static_cast<flag_t>(f)) {}
+struct SleepOptionFlagType; // Tag type for System.sleep() flags
+typedef particle::Flags<SleepOptionFlagType, uint32_t> SleepOptionFlags;
+typedef SleepOptionFlags::FlagType SleepOptionFlag;
 
-    inline SleepNetworkFlag(flag_t flag) : flag_(flag) {}
-
-    inline explicit operator flag_t() const { return flag_; }
-
-    inline flag_t flag() const { return flag_; }
-
-private:
-    flag_t flag_;
-};
-
-// Bring the system enum into global scope
-const SleepNetworkFlag SLEEP_NETWORK_OFF(SystemSleepNetwork::Off);
-const SleepNetworkFlag SLEEP_NETWORK_STANDBY(SystemSleepNetwork::Standby);
+const SleepOptionFlag SLEEP_NETWORK_OFF(static_cast<uint32_t>(SystemSleepOption::NetworkOff));
+const SleepOptionFlag SLEEP_NETWORK_STANDBY(static_cast<uint32_t>(SystemSleepOption::NetworkStandby));
+const SleepOptionFlag SLEEP_DISABLE_WKP_PIN(static_cast<uint32_t>(SystemSleepOption::DisableWkpPin));
 
 #if Wiring_LogConfig
 enum LoggingFeature {
@@ -121,14 +110,14 @@ public:
     }
 #endif
 
-    static void sleep(Spark_Sleep_TypeDef sleepMode, long seconds=0, SleepNetworkFlag flag=SLEEP_NETWORK_OFF);
-    inline static void sleep(Spark_Sleep_TypeDef sleepMode, SleepNetworkFlag flag, long seconds=0) {
+    static void sleep(Spark_Sleep_TypeDef sleepMode, long seconds=0, SleepOptionFlags flag=SLEEP_NETWORK_OFF);
+    inline static void sleep(Spark_Sleep_TypeDef sleepMode, SleepOptionFlags flag, long seconds=0) {
         sleep(sleepMode, seconds, flag);
     }
 
     inline static void sleep(long seconds) { sleep(SLEEP_MODE_WLAN, seconds); }
-    static void sleep(uint16_t wakeUpPin, InterruptMode edgeTriggerMode, long seconds=0, SleepNetworkFlag flag=SLEEP_NETWORK_OFF);
-    inline static void sleep(uint16_t wakeUpPin, InterruptMode edgeTriggerMode, SleepNetworkFlag flag, long seconds=0) {
+    static void sleep(uint16_t wakeUpPin, InterruptMode edgeTriggerMode, long seconds=0, SleepOptionFlags flag=SLEEP_NETWORK_OFF);
+    inline static void sleep(uint16_t wakeUpPin, InterruptMode edgeTriggerMode, SleepOptionFlags flag, long seconds=0) {
         sleep(wakeUpPin, edgeTriggerMode, seconds, flag);
     }
 

--- a/wiring/inc/spark_wiring_system.h
+++ b/wiring/inc/spark_wiring_system.h
@@ -125,26 +125,26 @@ public:
      * wakeup pins: std::initializer_list<pin_t>
      * trigger mode: single InterruptMode
      */
-    inline static void sleep(std::initializer_list<pin_t> pins, InterruptMode edgeTriggerMode, long seconds = 0, SleepNetworkFlag flag = SLEEP_NETWORK_OFF) {
+    inline static void sleep(std::initializer_list<pin_t> pins, InterruptMode edgeTriggerMode, long seconds = 0, SleepOptionFlags flag = SLEEP_NETWORK_OFF) {
         // This will only work in C++14
         // static_assert(pins.size() > 0, "Provided pin list is empty");
-        system_sleep_pins(pins.begin(), pins.size(), &edgeTriggerMode, 1, seconds, flag.flag(), nullptr);
+        system_sleep_pins(pins.begin(), pins.size(), &edgeTriggerMode, 1, seconds, flag.value(), nullptr);
     }
-    inline static void sleep(std::initializer_list<pin_t> pins, InterruptMode edgeTriggerMode, SleepNetworkFlag flag, long seconds = 0) {
+    inline static void sleep(std::initializer_list<pin_t> pins, InterruptMode edgeTriggerMode, SleepOptionFlags flag, long seconds = 0) {
         sleep(pins, edgeTriggerMode, seconds, flag);
     }
     /*
      * wakeup pins: std::initializer_list<pin_t>
      * trigger mode: std::initializer_list<InterruptMode>
      */
-    inline static void sleep(std::initializer_list<pin_t> pins, std::initializer_list<InterruptMode> edgeTriggerMode, long seconds = 0, SleepNetworkFlag flag = SLEEP_NETWORK_OFF) {
+    inline static void sleep(std::initializer_list<pin_t> pins, std::initializer_list<InterruptMode> edgeTriggerMode, long seconds = 0, SleepOptionFlags flag = SLEEP_NETWORK_OFF) {
         // This will only work in C++14
         // static_assert(pins.size() > 0, "Provided pin list is empty");
         // static_assert(edgeTriggerMode.size() > 0, "Provided InterruptMode list is empty");
 
-        system_sleep_pins(pins.begin(), pins.size(), edgeTriggerMode.begin(), edgeTriggerMode.size(), seconds, flag.flag(), nullptr);
+        system_sleep_pins(pins.begin(), pins.size(), edgeTriggerMode.begin(), edgeTriggerMode.size(), seconds, flag.value(), nullptr);
     }
-    inline static void sleep(std::initializer_list<pin_t> pins, std::initializer_list<InterruptMode> edgeTriggerMode, SleepNetworkFlag flag, long seconds = 0) {
+    inline static void sleep(std::initializer_list<pin_t> pins, std::initializer_list<InterruptMode> edgeTriggerMode, SleepOptionFlags flag, long seconds = 0) {
         sleep(pins, edgeTriggerMode, seconds, flag);
     }
 
@@ -152,10 +152,10 @@ public:
      * wakeup pins: pin_t* + size_t
      * trigger mode: single InterruptMode
      */
-    inline static void sleep(const pin_t* pins, size_t pinsSize, InterruptMode edgeTriggerMode, long seconds = 0, SleepNetworkFlag flag = SLEEP_NETWORK_OFF) {
-        system_sleep_pins(pins, pinsSize, &edgeTriggerMode, 1, seconds, flag.flag(), nullptr);
+    inline static void sleep(const pin_t* pins, size_t pinsSize, InterruptMode edgeTriggerMode, long seconds = 0, SleepOptionFlags flag = SLEEP_NETWORK_OFF) {
+        system_sleep_pins(pins, pinsSize, &edgeTriggerMode, 1, seconds, flag.value(), nullptr);
     }
-    inline static void sleep(const pin_t* pins, size_t pinsSize, InterruptMode edgeTriggerMode, SleepNetworkFlag flag, long seconds = 0) {
+    inline static void sleep(const pin_t* pins, size_t pinsSize, InterruptMode edgeTriggerMode, SleepOptionFlags flag, long seconds = 0) {
         sleep(pins, pinsSize, edgeTriggerMode, seconds, flag);
     }
 
@@ -163,10 +163,10 @@ public:
      * wakeup pins: pin_t* + size_t
      * trigger mode: InterruptMode* + size_t
      */
-    inline static void sleep(const pin_t* pins, size_t pinsSize, const InterruptMode* edgeTriggerMode, size_t edgeTriggerModeSize, long seconds = 0, SleepNetworkFlag flag = SLEEP_NETWORK_OFF) {
-        system_sleep_pins(pins, pinsSize, edgeTriggerMode, edgeTriggerModeSize, seconds, flag.flag(), nullptr);
+    inline static void sleep(const pin_t* pins, size_t pinsSize, const InterruptMode* edgeTriggerMode, size_t edgeTriggerModeSize, long seconds = 0, SleepOptionFlags flag = SLEEP_NETWORK_OFF) {
+        system_sleep_pins(pins, pinsSize, edgeTriggerMode, edgeTriggerModeSize, seconds, flag.value(), nullptr);
     }
-    inline static void sleep(const pin_t* pins, size_t pinsSize, const InterruptMode* edgeTriggerMode, size_t edgeTriggerModeSize, SleepNetworkFlag flag, long seconds = 0) {
+    inline static void sleep(const pin_t* pins, size_t pinsSize, const InterruptMode* edgeTriggerMode, size_t edgeTriggerModeSize, SleepOptionFlags flag, long seconds = 0) {
         sleep(pins, pinsSize, edgeTriggerMode, edgeTriggerModeSize, seconds, flag);
     }
 

--- a/wiring/src/spark_wiring_system.cpp
+++ b/wiring/src/spark_wiring_system.cpp
@@ -41,14 +41,14 @@ void SystemClass::reset(uint32_t data)
     HAL_Core_System_Reset_Ex(RESET_REASON_USER, data, nullptr);
 }
 
-void SystemClass::sleep(Spark_Sleep_TypeDef sleepMode, long seconds, SleepNetworkFlag network)
+void SystemClass::sleep(Spark_Sleep_TypeDef sleepMode, long seconds, SleepOptionFlags flags)
 {
-    system_sleep(sleepMode, seconds, network.flag(), NULL);
+    system_sleep(sleepMode, seconds, flags.value(), NULL);
 }
 
-void SystemClass::sleep(uint16_t wakeUpPin, InterruptMode edgeTriggerMode, long seconds, SleepNetworkFlag network)
+void SystemClass::sleep(uint16_t wakeUpPin, InterruptMode edgeTriggerMode, long seconds, SleepOptionFlags flags)
 {
-    system_sleep_pin(wakeUpPin, edgeTriggerMode, seconds, network.flag(), NULL);
+    system_sleep_pin(wakeUpPin, edgeTriggerMode, seconds, flags.value(), NULL);
 }
 
 uint32_t SystemClass::freeMemory()


### PR DESCRIPTION
<details>
  <summary><i>submission notes</i></summary>

```
**Important:** Please sanitize/remove any confidential info like usernames, passwords, org names, product names/ids, access tokens, client ids/secrets, or anything else you don't wish to share.

Please Read and Sign the Contributor License Agreement ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md)).

You may also delete this submission notes header if you'd like. Thank you for contributing!
```
</details>

### Problem

See #1345 

### Solution

Adds `SLEEP_DISABLE_WKP_PIN` `System.sleep()` flag to disable waking up from STANDBY (deep sleep).

### Steps to Test

- `wiring/api`

### Example App

```c
void setup() {
}

void loop() {
    System.sleep(SLEEP_MODE_DEEP, SLEEP_DISABLE_WKP_PIN, 60);
}
```

### References

- Closes #1345
- [CH1345]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] **TODO**: Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
