### PR TITLE
System.sleep() wake up reason

### DIFF
--- a/hal/src/core/core_hal.c
+++ b/hal/src/core/core_hal.c
@@ -281,7 +281,7 @@ void HAL_Core_Enter_Bootloader(bool persist)
 int32_t HAL_Core_Enter_Stop_Mode_Ext(const uint16_t* pins, size_t pins_count, const InterruptMode* mode, size_t mode_count, long seconds, void* reserved)
 {
     HAL_Core_Enter_Stop_Mode(pins != NULL && pins_count > 0 ? *pins : TOTAL_PINS, mode != NULL && mode_count > 0 ? (uint16_t)(*mode) : 0xffff, seconds);
-    return 0;
+    return -1;
 }
 
 void HAL_Core_Enter_Stop_Mode(uint16_t wakeUpPin, uint16_t edgeTriggerMode, long seconds)

--- a/hal/src/template/core_hal.cpp
+++ b/hal/src/template/core_hal.cpp
@@ -91,6 +91,11 @@ void HAL_Core_Execute_Standby_Mode(void)
 {
 }
 
+int HAL_Core_Get_Last_Reset_Info(int *reason, uint32_t *data, void *reserved)
+{
+    return -1;
+}
+
 /**
  * @brief  Computes the 32-bit CRC of a given buffer of byte data.
  * @param  pBuffer: pointer to the buffer containing the data to be computed

--- a/system/inc/system_dynalib.h
+++ b/system/inc/system_dynalib.h
@@ -98,6 +98,7 @@ DYNALIB_FN(BASE_IDX + 13, system, system_pool_alloc, void*(size_t, void*))
 DYNALIB_FN(BASE_IDX + 14, system, system_pool_free, void(void*, void*))
 DYNALIB_FN(BASE_IDX + 15, system, system_sleep_pins, int32_t(const uint16_t*, size_t, const InterruptMode*, size_t, long, uint32_t, void*))
 
+
 DYNALIB_END(system)
 
 #undef BASE_IDX

--- a/system/src/system_sleep.cpp
+++ b/system/src/system_sleep.cpp
@@ -178,9 +178,9 @@ int system_sleep_pin_impl(const uint16_t* pins, size_t pins_count, const Interru
 #endif
 
     led_set_update_enabled(0, nullptr); // Disable background LED updates
-    LED_Off(LED_RGB);
+    LED_Off(LED_RGB);    
 	system_power_management_sleep();
-    HAL_Core_Enter_Stop_Mode_Ext(pins, pins_count, modes, modes_count, seconds, nullptr);
+    int ret = HAL_Core_Enter_Stop_Mode_Ext(pins, pins_count, modes, modes_count, seconds, nullptr);
     led_set_update_enabled(1, nullptr); // Enable background LED updates
 
 #if PLATFORM_ID==PLATFORM_ELECTRON_PRODUCTION
@@ -204,7 +204,7 @@ int system_sleep_pin_impl(const uint16_t* pins, size_t pins_count, const Interru
     if (spark_cloud_flag_connected()) {
         Spark_Wake();
     }
-    return 0;
+    return ret;
 }
 
 /**

--- a/user/tests/app/sleep_multiple_pins/application.cpp
+++ b/user/tests/app/sleep_multiple_pins/application.cpp
@@ -165,8 +165,23 @@ void countdown(int c) {
     }
 }
 
+const char* getPinName(pin_t pin) {
+    for (unsigned i = 0; i < pinCount; i++) {
+        if (pins[i] == pin) {
+            return pin_names[i];
+        }
+    }
+    return "UNKNOWN";
+}
+
 void loop() {
     waitUntil(Serial.isConnected);
+    SleepResult r = System.sleepResult();
+    if (r.wokenUpByPin()) {
+        Serial.printlnf("The device was woken up by pin %s %lu", getPinName(r.pin()), r.pin());
+    } else if (r.wokenUpByRtc()) {
+        Serial.printlnf("The device was woken up by RTC");
+    }
     Serial.println("Press any key to enter STOP mode");
     Serial.println("You should be able to wake up your device using any of these pins:");
     for (unsigned i = 0; i < sizeof(pins)/sizeof(*pins); i++) {

--- a/user/tests/unit/system_task.cpp
+++ b/user/tests/unit/system_task.cpp
@@ -81,9 +81,4 @@ SCENARIO("System version info is retrieved", "[system,version]") {
 volatile uint8_t SPARK_CLOUD_CONNECT;
 volatile uint8_t SPARK_WLAN_SLEEP;
 
-int HAL_Core_Get_Last_Reset_Info(int *reason, uint32_t *data, void *reserved)
-{
-    return -1;
-}
-
 SystemClass System;

--- a/user/tests/unit/system_task.cpp
+++ b/user/tests/unit/system_task.cpp
@@ -81,4 +81,9 @@ SCENARIO("System version info is retrieved", "[system,version]") {
 volatile uint8_t SPARK_CLOUD_CONNECT;
 volatile uint8_t SPARK_WLAN_SLEEP;
 
+int HAL_Core_Get_Last_Reset_Info(int *reason, uint32_t *data, void *reserved)
+{
+    return -1;
+}
+
 SystemClass System;

--- a/user/tests/wiring/api/system.cpp
+++ b/user/tests/wiring/api/system.cpp
@@ -43,32 +43,34 @@ test(system_api) {
 
 test(system_sleep)
 {
-    API_COMPILE(System.sleep(60));
 
-    API_COMPILE(System.sleep(SLEEP_MODE_WLAN, 60));
+    // All sleep methods should return System.sleep()
+    API_COMPILE({ SleepResult r = System.sleep(60); (void)r; });
 
-    API_COMPILE(System.sleep(SLEEP_MODE_DEEP, 60));
+    API_COMPILE({ SleepResult r = System.sleep(SLEEP_MODE_WLAN, 60); (void)r; });
 
-    API_COMPILE(System.sleep(SLEEP_MODE_DEEP));
+    API_COMPILE({ SleepResult r = System.sleep(SLEEP_MODE_DEEP, 60); (void)r; });
 
-    API_COMPILE(System.sleep(A0, CHANGE));
-    API_COMPILE(System.sleep(A0, RISING));
-    API_COMPILE(System.sleep(A0, FALLING));
-    API_COMPILE(System.sleep(A0, FALLING, 20));
+    API_COMPILE({ SleepResult r = System.sleep(SLEEP_MODE_DEEP); (void)r; });
+
+    API_COMPILE({ SleepResult r = System.sleep(A0, CHANGE); (void)r; });
+    API_COMPILE({ SleepResult r = System.sleep(A0, RISING); (void)r; });
+    API_COMPILE({ SleepResult r = System.sleep(A0, FALLING); (void)r; });
+    API_COMPILE({ SleepResult r = System.sleep(A0, FALLING, 20); (void)r; });
 
     // with network flags
-    API_COMPILE(System.sleep(SLEEP_MODE_WLAN, 60, SLEEP_NETWORK_STANDBY));
+    API_COMPILE({ SleepResult r = System.sleep(SLEEP_MODE_WLAN, 60, SLEEP_NETWORK_STANDBY); (void)r; });
 
-    API_COMPILE(System.sleep(SLEEP_MODE_DEEP, 60, SLEEP_NETWORK_STANDBY));
-    API_COMPILE(System.sleep(SLEEP_MODE_DEEP, SLEEP_NETWORK_STANDBY, 60));
+    API_COMPILE({ SleepResult r = System.sleep(SLEEP_MODE_DEEP, 60, SLEEP_NETWORK_STANDBY); (void)r; });
+    API_COMPILE({ SleepResult r = System.sleep(SLEEP_MODE_DEEP, SLEEP_NETWORK_STANDBY, 60); (void)r; });
 
-    API_COMPILE(System.sleep(SLEEP_MODE_DEEP, SLEEP_NETWORK_STANDBY));
+    API_COMPILE({ SleepResult r = System.sleep(SLEEP_MODE_DEEP, SLEEP_NETWORK_STANDBY); (void)r; });
 
-    API_COMPILE(System.sleep(A0, CHANGE, SLEEP_NETWORK_STANDBY));
-    API_COMPILE(System.sleep(A0, RISING, SLEEP_NETWORK_STANDBY));
-    API_COMPILE(System.sleep(A0, FALLING, SLEEP_NETWORK_STANDBY));
-    API_COMPILE(System.sleep(A0, FALLING, 20, SLEEP_NETWORK_STANDBY));
-    API_COMPILE(System.sleep(A0, FALLING, SLEEP_NETWORK_STANDBY, 20));
+    API_COMPILE({ SleepResult r = System.sleep(A0, CHANGE, SLEEP_NETWORK_STANDBY); (void)r; });
+    API_COMPILE({ SleepResult r = System.sleep(A0, RISING, SLEEP_NETWORK_STANDBY); (void)r; });
+    API_COMPILE({ SleepResult r = System.sleep(A0, FALLING, SLEEP_NETWORK_STANDBY); (void)r; });
+    API_COMPILE({ SleepResult r = System.sleep(A0, FALLING, 20, SLEEP_NETWORK_STANDBY); (void)r; });
+    API_COMPILE({ SleepResult r = System.sleep(A0, FALLING, SLEEP_NETWORK_STANDBY, 20); (void)r; });
 
     // Multi-pin variants
     {
@@ -76,47 +78,64 @@ test(system_sleep)
          * wakeup pins: std::initializer_list<pin_t>
          * trigger mode: single InterruptMode
          */
-        API_COMPILE(System.sleep({D0, D1}, RISING));
+        API_COMPILE({ SleepResult r = System.sleep({D0, D1}, RISING); (void)r; });
 
         /*
          * wakeup pins: std::initializer_list<pin_t>
          * trigger mode: std::initializer_list<InterruptMode>
          */
-        API_COMPILE(System.sleep({D0, D1}, {RISING, FALLING}));
+        API_COMPILE({ SleepResult r = System.sleep({D0, D1}, {RISING, FALLING}); (void)r; });
 
         const pin_t pins_array[] = {D0, D1};
         const InterruptMode mode_array[] = {RISING, FALLING};
-    
+
         /*
          * wakeup pins: pin_t* + size_t
          * trigger mode: single InterruptMode
          */
-        API_COMPILE(System.sleep(pins_array, sizeof(pins_array)/sizeof(*pins_array), RISING));
-        API_COMPILE(System.sleep(pins_array, sizeof(pins_array)/sizeof(*pins_array), RISING, 20));
-        API_COMPILE(System.sleep(pins_array, sizeof(pins_array)/sizeof(*pins_array), RISING, SLEEP_NETWORK_STANDBY));
-        API_COMPILE(System.sleep(pins_array, sizeof(pins_array)/sizeof(*pins_array), RISING, 20, SLEEP_NETWORK_STANDBY));
-        API_COMPILE(System.sleep(pins_array, sizeof(pins_array)/sizeof(*pins_array), RISING, SLEEP_NETWORK_STANDBY, 20));
+        API_COMPILE({ SleepResult r = System.sleep(pins_array, sizeof(pins_array)/sizeof(*pins_array), RISING); (void)r; });
+        API_COMPILE({ SleepResult r = System.sleep(pins_array, sizeof(pins_array)/sizeof(*pins_array), RISING, 20); (void)r; });
+        API_COMPILE({ SleepResult r = System.sleep(pins_array, sizeof(pins_array)/sizeof(*pins_array), RISING, SLEEP_NETWORK_STANDBY); (void)r; });
+        API_COMPILE({ SleepResult r = System.sleep(pins_array, sizeof(pins_array)/sizeof(*pins_array), RISING, 20, SLEEP_NETWORK_STANDBY); (void)r; });
+        API_COMPILE({ SleepResult r = System.sleep(pins_array, sizeof(pins_array)/sizeof(*pins_array), RISING, SLEEP_NETWORK_STANDBY, 20); (void)r; });
 
         /*
          * wakeup pins: pin_t* + size_t
          * trigger mode: InterruptMode* + size_t
          */
-        API_COMPILE(System.sleep(pins_array, sizeof(pins_array)/sizeof(*pins_array), mode_array, sizeof(mode_array)/sizeof(*mode_array)));
-        API_COMPILE(System.sleep(pins_array, sizeof(pins_array)/sizeof(*pins_array), mode_array, sizeof(mode_array)/sizeof(*mode_array), 20));
-        API_COMPILE(System.sleep(pins_array, sizeof(pins_array)/sizeof(*pins_array), mode_array, sizeof(mode_array)/sizeof(*mode_array), SLEEP_NETWORK_STANDBY));
-        API_COMPILE(System.sleep(pins_array, sizeof(pins_array)/sizeof(*pins_array), mode_array, sizeof(mode_array)/sizeof(*mode_array), 20, SLEEP_NETWORK_STANDBY));
-        API_COMPILE(System.sleep(pins_array, sizeof(pins_array)/sizeof(*pins_array), mode_array, sizeof(mode_array)/sizeof(*mode_array), SLEEP_NETWORK_STANDBY, 20));
+        API_COMPILE({ SleepResult r = System.sleep(pins_array, sizeof(pins_array)/sizeof(*pins_array), mode_array, sizeof(mode_array)/sizeof(*mode_array)); (void)r; });
+        API_COMPILE({ SleepResult r = System.sleep(pins_array, sizeof(pins_array)/sizeof(*pins_array), mode_array, sizeof(mode_array)/sizeof(*mode_array), 20); (void)r; });
+        API_COMPILE({ SleepResult r = System.sleep(pins_array, sizeof(pins_array)/sizeof(*pins_array), mode_array, sizeof(mode_array)/sizeof(*mode_array), SLEEP_NETWORK_STANDBY); (void)r; });
+        API_COMPILE({ SleepResult r = System.sleep(pins_array, sizeof(pins_array)/sizeof(*pins_array), mode_array, sizeof(mode_array)/sizeof(*mode_array), 20, SLEEP_NETWORK_STANDBY); (void)r; });
+        API_COMPILE({ SleepResult r = System.sleep(pins_array, sizeof(pins_array)/sizeof(*pins_array), mode_array, sizeof(mode_array)/sizeof(*mode_array), SLEEP_NETWORK_STANDBY, 20); (void)r; });
     }
-
 	// SLEEP_DISABLE_WKP_PIN
-    API_COMPILE(System.sleep(SLEEP_MODE_DEEP, SLEEP_DISABLE_WKP_PIN));
-    API_COMPILE(System.sleep(SLEEP_MODE_DEEP, SLEEP_DISABLE_WKP_PIN, 60));
-    API_COMPILE(System.sleep(SLEEP_MODE_DEEP, 60, SLEEP_DISABLE_WKP_PIN));
+    API_COMPILE({ SleepResult r = Sleep.sleep(SLEEP_MODE_DEEP, SLEEP_DISABLE_WKP_PIN)});
+    API_COMPILE({ SleepResult r = System.sleep(SLEEP_MODE_DEEP, SLEEP_DISABLE_WKP_PIN, 60)});
+    API_COMPILE({ SleepResult r = System.sleep(SLEEP_MODE_DEEP, 60, SLEEP_DISABLE_WKP_PIN)});
 
     // Flags OR-ing
-    API_COMPILE(System.sleep(SLEEP_MODE_DEEP, SLEEP_DISABLE_WKP_PIN | SLEEP_NETWORK_STANDBY));
-    API_COMPILE(System.sleep(SLEEP_MODE_DEEP, SLEEP_DISABLE_WKP_PIN | SLEEP_NETWORK_STANDBY, 60));
-    API_COMPILE(System.sleep(SLEEP_MODE_DEEP, 60, SLEEP_DISABLE_WKP_PIN | SLEEP_NETWORK_STANDBY));
+    API_COMPILE({ SleepResult r = System.sleep(SLEEP_MODE_DEEP, SLEEP_DISABLE_WKP_PIN | SLEEP_NETWORK_STANDBY)});
+    API_COMPILE({ SleepResult r = System.sleep(SLEEP_MODE_DEEP, SLEEP_DISABLE_WKP_PIN | SLEEP_NETWORK_STANDBY, 60)});
+    API_COMPILE({ SleepResult r = System.sleep(SLEEP_MODE_DEEP, 60, SLEEP_DISABLE_WKP_PIN | SLEEP_NETWORK_STANDBY)});
+
+    API_COMPILE({
+        SleepResult r;
+        (void)r.reason();
+        (void)r.wokenUpByRtc();
+        (void)r.wokenUpByPin();
+
+        (void)r.pin();
+        (void)r.rtc();
+        (void)r.error();
+    });
+
+    API_COMPILE(System.wakeUpReason());
+    API_COMPILE(System.wokenUpByPin());
+    API_COMPILE(System.wokenUpByRtc());
+    API_COMPILE(System.wakeUpPin());
+    API_COMPILE(System.sleepResult());
+    API_COMPILE(System.sleepError());
 }
 
 test(system_mode) {

--- a/user/tests/wiring/api/system.cpp
+++ b/user/tests/wiring/api/system.cpp
@@ -108,17 +108,16 @@ test(system_sleep)
         API_COMPILE({ SleepResult r = System.sleep(pins_array, sizeof(pins_array)/sizeof(*pins_array), mode_array, sizeof(mode_array)/sizeof(*mode_array), SLEEP_NETWORK_STANDBY); (void)r; });
         API_COMPILE({ SleepResult r = System.sleep(pins_array, sizeof(pins_array)/sizeof(*pins_array), mode_array, sizeof(mode_array)/sizeof(*mode_array), 20, SLEEP_NETWORK_STANDBY); (void)r; });
         API_COMPILE({ SleepResult r = System.sleep(pins_array, sizeof(pins_array)/sizeof(*pins_array), mode_array, sizeof(mode_array)/sizeof(*mode_array), SLEEP_NETWORK_STANDBY, 20); (void)r; });
+		// SLEEP_DISABLE_WKP_PIN
+		API_COMPILE({ SleepResult r = System.sleep(SLEEP_MODE_DEEP, SLEEP_DISABLE_WKP_PIN); (void)r;});
+		API_COMPILE({ SleepResult r = System.sleep(SLEEP_MODE_DEEP, SLEEP_DISABLE_WKP_PIN, 60); (void)r;});
+		API_COMPILE({ SleepResult r = System.sleep(SLEEP_MODE_DEEP, 60, SLEEP_DISABLE_WKP_PIN); (void)r;});
+
+		// Flags OR-ing
+		API_COMPILE({ SleepResult r = System.sleep(SLEEP_MODE_DEEP, SLEEP_DISABLE_WKP_PIN | SLEEP_NETWORK_STANDBY); (void)r;});
+		API_COMPILE({ SleepResult r = System.sleep(SLEEP_MODE_DEEP, SLEEP_DISABLE_WKP_PIN | SLEEP_NETWORK_STANDBY, 60); (void)r;});
+		API_COMPILE({ SleepResult r = System.sleep(SLEEP_MODE_DEEP, 60, SLEEP_DISABLE_WKP_PIN | SLEEP_NETWORK_STANDBY); (void)r;});
     }
-	// SLEEP_DISABLE_WKP_PIN
-    API_COMPILE({ SleepResult r = Sleep.sleep(SLEEP_MODE_DEEP, SLEEP_DISABLE_WKP_PIN)});
-    API_COMPILE({ SleepResult r = System.sleep(SLEEP_MODE_DEEP, SLEEP_DISABLE_WKP_PIN, 60)});
-    API_COMPILE({ SleepResult r = System.sleep(SLEEP_MODE_DEEP, 60, SLEEP_DISABLE_WKP_PIN)});
-
-    // Flags OR-ing
-    API_COMPILE({ SleepResult r = System.sleep(SLEEP_MODE_DEEP, SLEEP_DISABLE_WKP_PIN | SLEEP_NETWORK_STANDBY)});
-    API_COMPILE({ SleepResult r = System.sleep(SLEEP_MODE_DEEP, SLEEP_DISABLE_WKP_PIN | SLEEP_NETWORK_STANDBY, 60)});
-    API_COMPILE({ SleepResult r = System.sleep(SLEEP_MODE_DEEP, 60, SLEEP_DISABLE_WKP_PIN | SLEEP_NETWORK_STANDBY)});
-
     API_COMPILE({
         SleepResult r;
         (void)r.reason();

--- a/wiring/inc/spark_wiring_system.h
+++ b/wiring/inc/spark_wiring_system.h
@@ -95,6 +95,13 @@ private:
     pin_t pin_ = std::numeric_limits<pin_t>::max();
 };
 
+inline SleepResult::SleepResult(WakeupReason r, system_error_t e, pin_t p)
+    : reason_(r),
+      err_(e),
+      pin_(p) {
+}
+
+
 class SystemClass {
 public:
 

--- a/wiring/src/spark_wiring_system.cpp
+++ b/wiring/src/spark_wiring_system.cpp
@@ -41,14 +41,17 @@ void SystemClass::reset(uint32_t data)
     HAL_Core_System_Reset_Ex(RESET_REASON_USER, data, nullptr);
 }
 
-void SystemClass::sleep(Spark_Sleep_TypeDef sleepMode, long seconds, SleepOptionFlags flags)
+SleepResult SystemClass::sleep(Spark_Sleep_TypeDef sleepMode, long seconds, SleepOptionFlags flags)
 {
     system_sleep(sleepMode, seconds, flags.value(), NULL);
+    System.sleepResult_ = SleepResult();
+    return System.sleepResult_;
 }
 
-void SystemClass::sleep(uint16_t wakeUpPin, InterruptMode edgeTriggerMode, long seconds, SleepOptionFlags flags)
-{
-    system_sleep_pin(wakeUpPin, edgeTriggerMode, seconds, flags.value(), NULL);
+SleepResult SystemClass::sleepPinImpl(const uint16_t* pins, size_t pins_count, const InterruptMode* modes, size_t modes_count, long seconds, SleepOptionFlags flags) {
+    int ret = system_sleep_pins(pins, pins_count, modes, modes_count, seconds, flags.value(), nullptr);
+    System.sleepResult_ = SleepResult(ret, pins, pins_count);
+    return System.sleepResult_;
 }
 
 uint32_t SystemClass::freeMemory()
@@ -70,4 +73,51 @@ bool SystemClass::enableFeature(LoggingFeature) {
 bool SystemClass::enableFeature(const WiFiTesterFeature feature) {
     WiFiTester::init();
     return true;
+}
+
+SleepResult::SleepResult(int ret, const pin_t* pins, size_t pinsSize) {
+    if (ret > 0) {
+        // pin
+        --ret;
+        if ((size_t)ret < pinsSize) {
+            pin_ = pins[ret];
+            reason_ = WAKEUP_REASON_PIN;
+            err_ = SYSTEM_ERROR_NONE;
+        }
+    } else if (ret == 0) {
+        reason_ = WAKEUP_REASON_RTC;
+        err_ = SYSTEM_ERROR_NONE;
+    } else {
+        err_ = static_cast<system_error_t>(ret);
+    }
+}
+
+SleepResult::SleepResult(WakeupReason r, system_error_t e, pin_t p)
+    : reason_(r),
+      err_(e),
+      pin_(p) {
+}
+
+WakeupReason SleepResult::reason() const {
+    return reason_;
+}
+
+bool SleepResult::wokenUpByRtc() const {
+    return reason_ == WAKEUP_REASON_RTC || reason_ == WAKEUP_REASON_PIN_OR_RTC;
+}
+
+bool SleepResult::wokenUpByPin() const {
+    return reason_ == WAKEUP_REASON_PIN || reason_ == WAKEUP_REASON_PIN_OR_RTC;
+}
+
+pin_t SleepResult::pin() const {
+    return pin_;
+}
+
+bool SleepResult::rtc() const {
+    return wokenUpByRtc();
+}
+
+system_error_t SleepResult::error() const {
+    return err_;
 }

--- a/wiring/src/spark_wiring_system.cpp
+++ b/wiring/src/spark_wiring_system.cpp
@@ -92,12 +92,6 @@ SleepResult::SleepResult(int ret, const pin_t* pins, size_t pinsSize) {
     }
 }
 
-SleepResult::SleepResult(WakeupReason r, system_error_t e, pin_t p)
-    : reason_(r),
-      err_(e),
-      pin_(p) {
-}
-
 WakeupReason SleepResult::reason() const {
     return reason_;
 }


### PR DESCRIPTION
<details>
  <summary><i>submission notes</i></summary>

```
**Important:** Please sanitize/remove any confidential info like usernames, passwords, org names, product names/ids, access tokens, client ids/secrets, or anything else you don't wish to share.

Please Read and Sign the Contributor License Agreement ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md)).

You may also delete this submission notes header if you'd like. Thank you for contributing!
```
</details>

**NOTE: Target branch is set to [feature/system-sleep-multiple-pins](https://github.com/spark/firmware/tree/feature/system-sleep-multiple-pins)**

### Problem

Users should be able to easily determine why the device woke up from STOP mode, especially after introduction of #1405 

### Solution

- All `System.sleep()` variants now return 
[`SleepResult`](https://github.com/spark/firmware/compare/feature/system-sleep-wkp-reason?expand=1#diff-9330b971deab5a41fa3008e5dea753f1R86) object that can be queried on the result of `System.sleep()` execution:
  - `WakeupReason SleepResult::reason();`
  - `bool SleepResult::wokenUpByRtc();`
  - `bool SleepResult::wokenUpByPin();`
  - `pin_t SleepResult::pin();`
  - `bool SleepResult::rtc();`
  - `system_error_t SleepResult::error();`
- A set of convenient functions was added to `System` class to retrieve information about the last sleep:
  - `WakeupReason System::wakeUpReason();`
  - `bool System::wokenUpByPin();`
  - `bool System::wokenUpByRtc();`
  - `pin_t System::wakeUpPin();`
  - `SleepResult System::sleepResult();`
  - `system_error_t System::sleepError();`
- `WakeupReason` is an enum of:
  - `WAKEUP_REASON_NONE = 0`
  - `WAKEUP_REASON_PIN = 1`
  - `WAKEUP_REASON_RTC = 2`
  - `WAKEUP_REASON_PIN_OR_RTC = 3`

### Steps to Test

- `wiring/api`
- `app/sleep_multiple_pins`

### Example App

See `app/sleep_multiple_pins`

### References

- #1405
- #1349
- [CH8894]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] **TODO:** Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
