### PR TITLE
Fix caching of the description CRCs in the backup RAM

### DIFF
--- a/communication/src/dtls_message_channel.cpp
+++ b/communication/src/dtls_message_channel.cpp
@@ -348,9 +348,9 @@ ProtocolError DTLSMessageChannel::establish(uint32_t& flags, uint32_t app_state_
 				sessionPersist.out_ctr[4],sessionPersist.out_ctr[5],sessionPersist.out_ctr[6],
 				sessionPersist.out_ctr[7], sessionPersist.next_coap_id);
 		sessionPersist.make_persistent();
-		uint32_t actual = sessionPersist.application_state_checksum(this->callbacks.calculate_crc);
-		LOG(INFO,"app state crc: %x, expected: %x", actual, app_state_crc);
-		if (actual==app_state_crc) {
+		const uint32_t cached = sessionPersist.application_state_checksum(this->callbacks.calculate_crc);
+		LOG(INFO,"app state crc: cached: %x, actual: %x", (unsigned)cached, (unsigned)app_state_crc);
+		if (cached==app_state_crc) {
 			LOG(WARN,"skipping hello message");
 			flags |= Protocol::SKIP_SESSION_RESUME_HELLO;
 		}

--- a/communication/src/protocol.cpp
+++ b/communication/src/protocol.cpp
@@ -490,8 +490,10 @@ ProtocolError Protocol::send_description(token_t token, message_id_t msg_id, int
 											  desc_flags & DESCRIBE_APPLICATION ? "A" : "",
 											  desc_flags & DESCRIBE_METRICS ? "M" : "");
 	ProtocolError error = channel.send(message);
-	if (error==NO_ERROR && descriptor.app_state_selector_info)
+	if (error==NO_ERROR && descriptor.app_state_selector_info &&
+            (desc_flags & DESCRIBE_APPLICATION || desc_flags & DESCRIBE_SYSTEM))
 	{
+        this->channel.command(Channel::SAVE_SESSION);
 		if (desc_flags & DESCRIBE_APPLICATION)
 		{
 			// have sent the describe message to the cloud so update the crc
@@ -502,6 +504,7 @@ ProtocolError Protocol::send_description(token_t token, message_id_t msg_id, int
 			// have sent the describe message to the cloud so update the crc
 			descriptor.app_state_selector_info(SparkAppStateSelector::DESCRIBE_SYSTEM, SparkAppStateUpdate::COMPUTE_AND_PERSIST, 0, nullptr);
 		}
+        this->channel.command(Channel::LOAD_SESSION);
 	}
 	return error;
 }

--- a/system/src/system_cloud_internal.cpp
+++ b/system/src/system_cloud_internal.cpp
@@ -550,10 +550,12 @@ uint32_t compute_cloud_state_checksum(SparkAppStateSelector::Enum stateSelector,
 			update_persisted_state([](SessionPersistData& data){
 				data.describe_app_crc = compute_describe_app_checksum();
 			});
+            break;
 		case SparkAppStateSelector::DESCRIBE_SYSTEM:
 			update_persisted_state([](SessionPersistData& data){
 				data.describe_system_crc = compute_describe_system_checksum();
 			});
+            break;
 		}
 	}
 	else if (operation==SparkAppStateUpdate::PERSIST && stateSelector==SparkAppStateSelector::SUBSCRIPTIONS)


### PR DESCRIPTION
### Problem

This PR fixes #1172 by ensuring that the application/system description checksums stored in the backup RAM don't get overwritten by invalid values when DTLS context is updated.

### Steps to Test

1. Flash a blank application with enabled logging to an Electron.
2. Toggle the power off and on to ensure that the persistent session data is invalidated.
3. Check that the device sends the HELLO message.
4. Flash the same application binary to the device OTA.
5. Check that the device skips sending the HELLO message.

### References

- [CH8911]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)