### PR TITLE
Guard cellular_command() with a global lock

### DIFF
--- a/hal/inc/cellular_hal.h
+++ b/hal/inc/cellular_hal.h
@@ -153,6 +153,16 @@ cellular_result_t cellular_imsi_to_network_provider(void* reserved);
  */
 const CellularNetProvData cellular_network_provider_data_get(void* reserved);
 
+/**
+ * Acquires the modem lock.
+ */
+int cellular_lock(void* reserved);
+
+/**
+ * Releases the modem lock.
+ */
+void cellular_unlock(void* reserved);
+
 #ifdef __cplusplus
 }
 #endif

--- a/hal/inc/hal_dynalib_cellular.h
+++ b/hal/inc/hal_dynalib_cellular.h
@@ -68,6 +68,8 @@ DYNALIB_FN(27, hal_cellular, cellular_pause, cellular_result_t(void*))
 DYNALIB_FN(28, hal_cellular, cellular_resume, cellular_result_t(void*))
 DYNALIB_FN(29, hal_cellular, cellular_imsi_to_network_provider, cellular_result_t(void*))
 DYNALIB_FN(30, hal_cellular, cellular_network_provider_data_get, const CellularNetProvData(void*))
+DYNALIB_FN(31, hal_cellular, cellular_lock, int(void*))
+DYNALIB_FN(32, hal_cellular, cellular_unlock, void(void*))
 DYNALIB_END(hal_cellular)
 
 #endif  // PLATFORM_ID == 10

--- a/hal/src/electron/cellular_hal.cpp
+++ b/hal/src/electron/cellular_hal.cpp
@@ -197,9 +197,7 @@ cellular_result_t cellular_command(_CALLBACKPTR_MDM cb, void* param,
     va_start(args, format);
     vsnprintf(buf, sizeof(buf), format, args);
     va_end(args);
-    electronMDM.sendFormated(buf);
-
-    return electronMDM.waitFinalResp((MDMParser::_CALLBACKPTR)cb, (void*)param, timeout_ms);
+    return electronMDM.command(buf, cb, param, timeout_ms);
 }
 
 cellular_result_t _cellular_data_usage_set(CellularDataHal &data, const MDM_DataUsage &data_usage, bool ret)

--- a/hal/src/electron/cellular_hal.cpp
+++ b/hal/src/electron/cellular_hal.cpp
@@ -192,12 +192,11 @@ cellular_result_t cellular_signal(CellularSignalHal* signal, cellular_signal_t* 
 cellular_result_t cellular_command(_CALLBACKPTR_MDM cb, void* param,
                           system_tick_t timeout_ms, const char* format, ...)
 {
-    char buf[256];
     va_list args;
     va_start(args, format);
-    vsnprintf(buf, sizeof(buf), format, args);
+    const int ret = electronMDM.sendCommandWithArgs(format, args, cb, param, timeout_ms);
     va_end(args);
-    return electronMDM.command(buf, cb, param, timeout_ms);
+    return ret;
 }
 
 cellular_result_t _cellular_data_usage_set(CellularDataHal &data, const MDM_DataUsage &data_usage, bool ret)

--- a/hal/src/electron/cellular_hal.cpp
+++ b/hal/src/electron/cellular_hal.cpp
@@ -318,4 +318,15 @@ const CellularNetProvData cellular_network_provider_data_get(void* reserved)
     return CELLULAR_NET_PROVIDER_DATA[cellularNetProv];
 }
 
+int cellular_lock(void* reserved)
+{
+    electronMDM.lock();
+    return 0;
+}
+
+void cellular_unlock(void* reserved)
+{
+    electronMDM.unlock();
+}
+
 #endif // !defined(HAL_CELLULAR_EXCLUDE)

--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -376,6 +376,15 @@ int MDMParser::waitFinalResp(_CALLBACKPTR cb /* = NULL*/,
     return WAIT;
 }
 
+int MDMParser::command(const char* cmd, _CALLBACKPTR cb, void* param, system_tick_t timeout)
+{
+    LOCK();
+    send(cmd, strlen(cmd));
+    const int ret = waitFinalResp(cb, param, timeout);
+    UNLOCK();
+    return ret;
+}
+
 int MDMParser::_cbString(int type, const char* buf, int len, char* str)
 {
     if (str && (type == TYPE_UNKNOWN)) {

--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -405,6 +405,16 @@ int MDMParser::sendCommandWithArgs(const char* fmt, va_list args, _CALLBACKPTR c
     return ret;
 }
 
+void MDMParser::lock()
+{
+    mdm_mutex.lock();
+}
+
+void MDMParser::unlock()
+{
+    mdm_mutex.unlock();
+}
+
 int MDMParser::_cbString(int type, const char* buf, int len, char* str)
 {
     if (str && (type == TYPE_UNKNOWN)) {

--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -214,14 +214,34 @@ int MDMParser::send(const char* buf, int len)
 }
 
 int MDMParser::sendFormated(const char* format, ...) {
-    if (_cancel_all_operations) return 0;
-
-    char buf[MAX_SIZE];
     va_list args;
     va_start(args, format);
-    int len = vsnprintf(buf,sizeof(buf), format, args);
+    const int ret = sendFormattedWithArgs(format, args);
     va_end(args);
-    return send(buf, len);
+    return ret;
+}
+
+int MDMParser::sendFormattedWithArgs(const char* format, va_list args) {
+    if (_cancel_all_operations) {
+        return 0;
+    }
+    va_list argsCopy;
+    va_copy(argsCopy, args);
+    char buf[128];
+    int n = vsnprintf(buf, sizeof(buf), format, args);
+    if (n >= 0) {
+        if ((size_t)n < sizeof(buf)) {
+            n = send(buf, n);
+        } else {
+            char buf[n + 1]; // Use larger buffer
+            n = vsnprintf(buf, sizeof(buf), format, argsCopy);
+            if (n >= 0) {
+                n = send(buf, n);
+            }
+        }
+    }
+    va_end(argsCopy);
+    return n;
 }
 
 int MDMParser::waitFinalResp(_CALLBACKPTR cb /* = NULL*/,
@@ -376,10 +396,10 @@ int MDMParser::waitFinalResp(_CALLBACKPTR cb /* = NULL*/,
     return WAIT;
 }
 
-int MDMParser::command(const char* cmd, _CALLBACKPTR cb, void* param, system_tick_t timeout)
+int MDMParser::sendCommandWithArgs(const char* fmt, va_list args, _CALLBACKPTR cb, void* param, system_tick_t timeout)
 {
     LOCK();
-    send(cmd, strlen(cmd));
+    sendFormattedWithArgs(fmt, args);
     const int ret = waitFinalResp(cb, param, timeout);
     UNLOCK();
     return ret;

--- a/hal/src/electron/modem/mdm_hal.h
+++ b/hal/src/electron/modem/mdm_hal.h
@@ -461,6 +461,12 @@ public:
     int sendCommandWithArgs(const char* fmt, va_list args, _CALLBACKPTR cb = NULL, void* param = NULL,
             system_tick_t timeout = 10000);
 
+    /** Acquires the modem lock. */
+    void lock();
+
+    /** Releases the modem lock. */
+    void unlock();
+
 protected:
     /** Write bytes to the physical interface. This function should be
         implemented in a inherited class.
@@ -501,12 +507,7 @@ protected:
         \param index the index of the received SMS
     */
     void SMSreceived(int index);
-protected:
-    // for rtos over riding by useing Rtos<MDMxx>
-    //! override the lock in a rtos system
-    virtual void lock(void)        { }
-    //! override the unlock in a rtos system
-    virtual void unlock(void)      { }
+
 protected:
     // parsing callbacks for different AT commands and their parameter arguments
     static int _cbString(int type, const char* buf, int len, char* str);

--- a/hal/src/electron/modem/mdm_hal.h
+++ b/hal/src/electron/modem/mdm_hal.h
@@ -412,6 +412,9 @@ public:
     */
     int sendFormated(const char* format, ...);
 
+    /** This method is similar to sendFormated() but takes the formatting arguments as va_list */
+    int sendFormattedWithArgs(const char* format, va_list args);
+
     /** callback function for #waitFinalResp with void* as argument
         \param type the #getLine response
         \param buf the parsed line
@@ -447,14 +450,16 @@ public:
     }
 
     /** Send AT command and wait for a response.
-        \param cmd command string (CRLF terminated)
+        \param fmt the format string (CRLF terminated)
+        \param args the formatting arguments
         \param cb the optional callback function
         \param param the optional callback function parameter
         \param timeout the response timeout in milliseconds
-        \sa send
+        \sa sendFormated
         \sa waitFinalResp
     */
-    int command(const char* cmd, _CALLBACKPTR cb = NULL, void* param = NULL, system_tick_t timeout = 10000);
+    int sendCommandWithArgs(const char* fmt, va_list args, _CALLBACKPTR cb = NULL, void* param = NULL,
+            system_tick_t timeout = 10000);
 
 protected:
     /** Write bytes to the physical interface. This function should be

--- a/hal/src/electron/modem/mdm_hal.h
+++ b/hal/src/electron/modem/mdm_hal.h
@@ -446,6 +446,16 @@ public:
         return waitFinalResp((_CALLBACKPTR)cb, (void*)param, timeout_ms);
     }
 
+    /** Send AT command and wait for a response.
+        \param cmd command string (CRLF terminated)
+        \param cb the optional callback function
+        \param param the optional callback function parameter
+        \param timeout the response timeout in milliseconds
+        \sa send
+        \sa waitFinalResp
+    */
+    int command(const char* cmd, _CALLBACKPTR cb = NULL, void* param = NULL, system_tick_t timeout = 10000);
+
 protected:
     /** Write bytes to the physical interface. This function should be
         implemented in a inherited class.

--- a/user/tests/wiring/api/cellular.cpp
+++ b/user/tests/wiring/api/cellular.cpp
@@ -138,4 +138,9 @@ test(api_cellular_resolve) {
     (void)ip;
 }
 
+test(api_cellular_lock_unlock) {
+    API_COMPILE(Cellular.lock());
+    API_COMPILE(Cellular.unlock());
+}
+
 #endif

--- a/wiring/inc/spark_wiring_cellular.h
+++ b/wiring/inc/spark_wiring_cellular.h
@@ -132,6 +132,16 @@ public:
         return (inet_gethostbyname(name, strlen(name), &ip, *this, NULL)<0) ?
                 IPAddress(uint32_t(0)) : IPAddress(ip);
     }
+
+    void lock()
+    {
+        cellular_lock(nullptr);
+    }
+
+    void unlock()
+    {
+        cellular_unlock(nullptr);
+    }
 };
 
 


### PR DESCRIPTION
### Problem

This PR fixes #1298 by guarding the implementation of `cellular_command()` with the Cellular HAL's global lock.

### Steps to Test

Flash the following application to an Electron, and ensure that repeated attempts to update the device OTA don't cause communication errors and hard faults.

```cpp
#include "application.h"

SYSTEM_THREAD(ENABLED)

namespace {

const Serial1LogHandler logHandler(115200, LOG_LEVEL_INFO, {
    { "app", LOG_LEVEL_ALL }
});

const unsigned INTERVAL = 500;
unsigned lastMillis = 0;

void onFirmwareUpdate() {
    lastMillis = millis();
}

} // namespace

void setup() {
    System.on(firmware_update_pending, onFirmwareUpdate);
}

void loop() {
    if (lastMillis != 0) {
        if (!Particle.connected()) {
            Log.info("disconnected");
            lastMillis = 0;
        } else if (millis() - lastMillis >= INTERVAL) {
            Log.info("sending command");
            Cellular.command("AT\r\n");
            lastMillis = millis();
        }
    }
}
```

### References

- [CH8908]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)