### PR TITLE
Generalize FuelGauge to also use alternative I2C interfaces (2nd atte…

### DIFF
--- a/wiring/inc/spark_wiring_fuel.h
+++ b/wiring/inc/spark_wiring_fuel.h
@@ -50,12 +50,16 @@ namespace detail {
 }
 
 class FuelGauge {
-
+  private: 
+  
+	TwoWire *_i2c = NULL;
+	
   public:
 
     FuelGauge(bool _lock = false);
     ~FuelGauge();
-    boolean begin();
+    boolean begin();				// will assume Wire3 for Electron, otherwise Wire
+	boolean begin(TwoWire & i2c);	// for dedicated selection of I2C interface
     float getVCell();
     float getSoC();
     float getNormalizedSoC();

--- a/wiring/src/spark_wiring_fuel.cpp
+++ b/wiring/src/spark_wiring_fuel.cpp
@@ -243,9 +243,11 @@ void FuelGauge::readRegister(byte startAddress, byte &MSB, byte &LSB) {
 		MSB = _i2c->read();
 		LSB = _i2c->read();
 	}
+#if ( SYSTEM_VERSION >=  0x00060000 )
 	else { // e.g. since FuelGauge::begin() wasn't called
 		Log.error("I2C interface not initialized! Has FuelGauge::begin() been called earlier?");
 	}
+#endif
 }
 
 void FuelGauge::writeRegister(byte address, byte MSB, byte LSB) {
@@ -257,9 +259,11 @@ void FuelGauge::writeRegister(byte address, byte MSB, byte LSB) {
 		_i2c->write(LSB);
 		_i2c->endTransmission(true);
 	}
+#if ( SYSTEM_VERSION >=  0x00060000 )
 	else { // e.g. since FuelGauge::begin() wasn't called
 		Log.error("I2C interface not initialized! Has FuelGauge::begin() been called earlier?");
 	}
+#endif
 }
 
 bool FuelGauge::lock() {
@@ -267,7 +271,9 @@ bool FuelGauge::lock() {
 		return _i2c->lock();
 	}
 	else { // e.g. since FuelGauge::begin() wasn't called
+#if ( SYSTEM_VERSION >=  0x00060000 )
 		Log.error("I2C interface not initialized! Has FuelGauge::begin() been called earlier?");
+#endif
 		return false;
 	}
 }
@@ -277,7 +283,9 @@ bool FuelGauge::unlock() {
 		return _i2c->unlock();
 	}
 	else { // e.g. since FuelGauge::begin() wasn't called
+#if ( SYSTEM_VERSION >=  0x00060000 )
 		Log.error("I2C interface not initialized! Has FuelGauge::begin() been called earlier?");
+#endif
 		return false;
 	}
 }

--- a/wiring/src/spark_wiring_fuel.cpp
+++ b/wiring/src/spark_wiring_fuel.cpp
@@ -45,8 +45,28 @@ FuelGauge::~FuelGauge()
 
 boolean FuelGauge::begin()
 {
-	// this should be unecessary since, begin is already called from pmic setup
-	return 1;
+#if (PLATFORM_ID == PLATFORM_ELECTRON_PRODUCTION) // what PRODUCT_ID will E0 get?
+	return this->begin(Wire3);  // with Electron the fuel gauge will be attached to Wire3
+#else                                             
+   return this->begin(Wire);   // otherwise we assume it to be on default Wire
+#endif
+}
+ 
+boolean FuelGauge::begin(TwoWire& i2c)
+{
+	_i2c = &i2c;
+	/* as per comment of Mat pointers will always be initialzed 
+	//if (_i2c) { 
+	*/
+
+    if (!_i2c->isEnabled()) 
+		_i2c->begin();
+    return _i2c->isEnabled();
+
+	/*
+	//}
+	//return 0;
+	*/
 }
 
 namespace detail {
@@ -183,6 +203,7 @@ void FuelGauge::quickStart() {
 }
 
 void FuelGauge::sleep() {
+
     std::lock_guard<FuelGauge> l(*this);
 	byte MSB = 0;
 	byte LSB = 0;
@@ -206,45 +227,57 @@ void FuelGauge::wakeup() {
 
 
 void FuelGauge::readConfigRegister(byte &MSB, byte &LSB) {
-
 	readRegister(CONFIG_REGISTER, MSB, LSB);
 }
 
 
 void FuelGauge::readRegister(byte startAddress, byte &MSB, byte &LSB) {
     std::lock_guard<FuelGauge> l(*this);
-#if Wiring_Wire3
-	Wire3.beginTransmission(MAX17043_ADDRESS);
-    Wire3.write(startAddress);
-    Wire3.endTransmission(true);
+	
+	if (_i2c) { 
+		_i2c->beginTransmission(MAX17043_ADDRESS);
+		_i2c->write(startAddress);
+		_i2c->endTransmission(true);
 
-    Wire3.requestFrom(MAX17043_ADDRESS, 2, true);
-    MSB = Wire3.read();
-    LSB = Wire3.read();
-#endif
+		_i2c->requestFrom(MAX17043_ADDRESS, 2, true);
+		MSB = _i2c->read();
+		LSB = _i2c->read();
+	}
+	else { // e.g. since FuelGauge::begin() wasn't called
+		Log.error("I2C interface not initialized! Has FuelGauge::begin() been called earlier?");
+	}
 }
 
 void FuelGauge::writeRegister(byte address, byte MSB, byte LSB) {
     std::lock_guard<FuelGauge> l(*this);
-#if Wiring_Wire3
-	Wire3.beginTransmission(MAX17043_ADDRESS);
-    Wire3.write(address);
-    Wire3.write(MSB);
-    Wire3.write(LSB);
-    Wire3.endTransmission(true);
-#endif
+	if (_i2c) { 
+		_i2c->beginTransmission(MAX17043_ADDRESS);
+		_i2c->write(address);
+		_i2c->write(MSB);
+		_i2c->write(LSB);
+		_i2c->endTransmission(true);
+	}
+	else { // e.g. since FuelGauge::begin() wasn't called
+		Log.error("I2C interface not initialized! Has FuelGauge::begin() been called earlier?");
+	}
 }
 
 bool FuelGauge::lock() {
-#if Wiring_Wire3
-    return Wire3.lock();
-#endif
-    return false;
+	if (_i2c) { 
+		return _i2c->lock();
+	}
+	else { // e.g. since FuelGauge::begin() wasn't called
+		Log.error("I2C interface not initialized! Has FuelGauge::begin() been called earlier?");
+		return false;
+	}
 }
 
 bool FuelGauge::unlock() {
-#if Wiring_Wire3
-    return Wire3.unlock();
-#endif
-    return false;
+	if (_i2c) { 
+		return _i2c->unlock();
+	}
+	else { // e.g. since FuelGauge::begin() wasn't called
+		Log.error("I2C interface not initialized! Has FuelGauge::begin() been called earlier?");
+		return false;
+	}
 }

--- a/wiring/src/spark_wiring_fuel.cpp
+++ b/wiring/src/spark_wiring_fuel.cpp
@@ -243,11 +243,9 @@ void FuelGauge::readRegister(byte startAddress, byte &MSB, byte &LSB) {
 		MSB = _i2c->read();
 		LSB = _i2c->read();
 	}
-#if ( SYSTEM_VERSION >=  0x00060000 )
 	else { // e.g. since FuelGauge::begin() wasn't called
-		Log.error("I2C interface not initialized! Has FuelGauge::begin() been called earlier?");
+		DEBUG("I2C interface not initialized! Has FuelGauge::begin() been called earlier?");
 	}
-#endif
 }
 
 void FuelGauge::writeRegister(byte address, byte MSB, byte LSB) {
@@ -259,11 +257,9 @@ void FuelGauge::writeRegister(byte address, byte MSB, byte LSB) {
 		_i2c->write(LSB);
 		_i2c->endTransmission(true);
 	}
-#if ( SYSTEM_VERSION >=  0x00060000 )
 	else { // e.g. since FuelGauge::begin() wasn't called
-		Log.error("I2C interface not initialized! Has FuelGauge::begin() been called earlier?");
+		DEBUG("I2C interface not initialized! Has FuelGauge::begin() been called earlier?");
 	}
-#endif
 }
 
 bool FuelGauge::lock() {
@@ -271,9 +267,7 @@ bool FuelGauge::lock() {
 		return _i2c->lock();
 	}
 	else { // e.g. since FuelGauge::begin() wasn't called
-#if ( SYSTEM_VERSION >=  0x00060000 )
-		Log.error("I2C interface not initialized! Has FuelGauge::begin() been called earlier?");
-#endif
+		DEBUG("I2C interface not initialized! Has FuelGauge::begin() been called earlier?");
 		return false;
 	}
 }
@@ -283,9 +277,7 @@ bool FuelGauge::unlock() {
 		return _i2c->unlock();
 	}
 	else { // e.g. since FuelGauge::begin() wasn't called
-#if ( SYSTEM_VERSION >=  0x00060000 )
-		Log.error("I2C interface not initialized! Has FuelGauge::begin() been called earlier?");
-#endif
+		DEBUG("I2C interface not initialized! Has FuelGauge::begin() been called earlier?");
 		return false;
 	}
 }


### PR DESCRIPTION
To enable Particle Power Shield to use spark_wiring_fuel without extra
library as mentioned in connection with this issue
#1275

Replaces PR #1297 (since I couldn't rebase my original repo :blush:)