### PR TITLE
Fixes GCC virtual device running with UDP protocol

### DIFF
--- a/hal/src/gcc/socket_hal.cpp
+++ b/hal/src/gcc/socket_hal.cpp
@@ -441,9 +441,7 @@ sock_handle_t socket_create(uint8_t family, uint8_t type, uint8_t protocol, uint
         if (result)				// error
             return result;
 
-        std::string address_mcast = "224.0.0.251";
-        boost::asio::ip::address mcast_addr = boost::asio::ip::address::from_string(address_mcast, ec);
-        boost::asio::ip::udp::endpoint listen_endpoint(mcast_addr, port);
+        boost::asio::ip::udp::endpoint listen_endpoint(ip::udp::v4(), port);
         socket.open(listen_endpoint.protocol(), ec);
 
         socket.set_option(boost::asio::ip::udp::socket::reuse_address(true));

--- a/system/src/system_cloud_internal.cpp
+++ b/system/src/system_cloud_internal.cpp
@@ -1104,8 +1104,13 @@ int spark_cloud_socket_connect()
     ip_address_error = determine_connection_address(ip_addr, port, server_addr, udp);
     if (!ip_address_error)
     {
-    		uint8_t local_port_offset = (PLATFORM_ID==3) ? 100 : 0;
-        sparkSocket = socket_create(AF_INET, udp ? SOCK_DGRAM : SOCK_STREAM, udp ? IPPROTO_UDP : IPPROTO_TCP, port+local_port_offset, NIF_DEFAULT);
+#if PLATFORM_ID == 3
+        // Use ephemeral port
+        uint16_t bport = 0;
+#else
+        uint16_t bport = port;
+#endif
+        sparkSocket = socket_create(AF_INET, udp ? SOCK_DGRAM : SOCK_STREAM, udp ? IPPROTO_UDP : IPPROTO_TCP, bport, NIF_DEFAULT);
         DEBUG("socketed udp=%d, sparkSocket=%d, %d", udp, sparkSocket, socket_handle_valid(sparkSocket));
     }
 


### PR DESCRIPTION
<details>
  <summary><i>submission notes</i></summary>

```
**Important:** Please sanitize/remove any confidential info like usernames, passwords, org names, product names/ids, access tokens, client ids/secrets, or anything else you don't wish to share.

Please Read and Sign the Contributor License Agreement ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md)).

You may also delete this submission notes header if you'd like. Thank you for contributing!
```
</details>

### Problem

There are two issues that prevent GCC virtual device to successfully connect to the cloud with UDP:
1. (main) The UDP socket is being bound to a multicast address 224.0.0.251, instead of 0.0.0.0 or some interface address
2. Cloud sockets use the same source UDP port, which prevents from running several virtual devices on the same host.

### Solution

1. Bind to 0.0.0.0
2. Use ephemeral source port when creating UDP cloud socket

### Steps to Test

Compile `PLATFORM=gcc` and test whether it can connect to the cloud with UDP protocol.

### Example App

N/A

### References

- [CH10641]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
