### PR TITLE
[Electron] connect_cancel() fix

### DIFF
--- a/hal/src/electron/cellular_hal.cpp
+++ b/hal/src/electron/cellular_hal.cpp
@@ -305,7 +305,7 @@ cellular_result_t cellular_pause(void* reserved)
 
 cellular_result_t cellular_resume(void* reserved)
 {
-    electronMDM.resume();
+    electronMDM.resumeRecv();
     return 0;
 }
 

--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -2352,7 +2352,7 @@ void MDMElectronSerial::pause()
     rxPause();
 }
 
-void MDMElectronSerial::resume()
+void MDMElectronSerial::resumeRecv()
 {
     LOCK();
     rxResume();

--- a/hal/src/electron/modem/mdm_hal.h
+++ b/hal/src/electron/modem/mdm_hal.h
@@ -603,7 +603,7 @@ public:
     }
 
     void pause();
-    void resume();
+    void resumeRecv();
 
 protected:
     /** Write bytes to the physical interface.

--- a/system/src/system_network_cellular.h
+++ b/system/src/system_network_cellular.h
@@ -83,6 +83,8 @@ protected:
             // ensure after connection exits the cancel flag is cleared if it was set during connection
             if (connect_cancelled) {
                 require_resume = true;
+                // This flag needs to be reset, otherwise the next connect_cancel() will do nothing
+                connect_cancelled = false;
             }
             connecting = false;
         }


### PR DESCRIPTION
<details>
  <summary><i>submission notes</i></summary>

```
**Important:** Please sanitize/remove any confidential info like usernames, passwords, org names, product names/ids, access tokens, client ids/secrets, or anything else you don't wish to share.

Please Read and Sign the Contributor License Agreement ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md)).

You may also delete this submission notes header if you'd like. Thank you for contributing!
```
</details>

### Problem

Only the first `CellularNetworkInterface::connect_cancel()` call succeeds, subsequent calls do not cancel running connection attempt due to the fact that `connect_cancelled` flag is never cleared.

### Solution

Clear it in `CellularNetworkInterface::connect_finalize()`.

This PR also fixes a method name clash between `MDMElectronSerial::resume()` and `MDMParser::resume()`.

### Steps to Test

I've encountered this issue while testing sleep modes on Electron.
1. Use `SYSTEM_THREAD(ENABLED)`
2. Enter sleep (STOP mode)
2. After waking up, do another sleep attempt while Electron is still trying to connect to the network
3. Electron will not enter sleep mode until it manages to connect

### Example App

N/A

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
