### PR TITLE
Serialize access to the CRC peripheral (STM32F2xx)

### DIFF
--- a/bootloader/src/stm32f2xx/concurrent_hal.c
+++ b/bootloader/src/stm32f2xx/concurrent_hal.c
@@ -1,12 +1,15 @@
-
-int os_thread_yield() {
+int os_thread_yield(void) {
 	return 0;
 }
 
-void __flash_acquire() {
-
+void __flash_acquire(void) {
 }
 
-void __flash_release() {
+void __flash_release(void) {
+}
 
+void periph_lock(void) {
+}
+
+void periph_unlock(void) {
 }

--- a/hal/src/stm32f2xx/concurrent_hal.cpp
+++ b/hal/src/stm32f2xx/concurrent_hal.cpp
@@ -36,9 +36,11 @@
 #include <mutex>
 #include <atomic>
 #include "flash_acquire.h"
+#include "periph_lock.h"
 #include "core_hal.h"
 #include "logging.h"
 #include "atomic_flag_mutex.h"
+#include "static_recursive_mutex.h"
 #include "service_debug.h"
 
 #if PLATFORM_ID == 6 || PLATFORM_ID == 8
@@ -66,6 +68,11 @@ static_assert(sizeof(uint32_t)==sizeof(void*), "Requires uint32_t to be same siz
 #define _CREATE_NAME_TYPE const signed char
 #endif
 
+namespace {
+
+StaticRecursiveMutex g_periphMutex;
+
+} // namespace
 
 /**
  * Creates a new thread.
@@ -518,4 +525,18 @@ void __flash_release() {
         return;
     }
     flash_lock.unlock();
+}
+
+void periph_lock() {
+    if (!rtos_started) {
+        return;
+    }
+    g_periphMutex.lock();
+}
+
+void periph_unlock() {
+    if (!rtos_started) {
+        return;
+    }
+    g_periphMutex.unlock();
 }

--- a/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/inc/periph_lock.h
+++ b/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/inc/periph_lock.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Acquire the global peripherals lock. The lock is recursive.
+ */
+void periph_lock(void);
+
+/**
+ * Release the global peripherals lock.
+ */
+void periph_unlock(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/src/hw_config.c
+++ b/platform/MCU/STM32F2xx/SPARK_Firmware_Driver/src/hw_config.c
@@ -34,6 +34,7 @@
 #include "rgbled.h"
 #include "hal_irq_flag.h"
 #include "system_flags_impl.h"
+#include "periph_lock.h"
 
 /* Private typedef -----------------------------------------------------------*/
 
@@ -972,6 +973,8 @@ void Bootloader_Update_Version(uint16_t bootloaderVersion)
  */
 uint32_t Compute_CRC32(const uint8_t *pBuffer, uint32_t bufferSize)
 {
+    periph_lock();
+
     /* Hardware CRC32 calculation */
     uint32_t i, j;
     uint32_t Data;
@@ -1008,6 +1011,8 @@ uint32_t Compute_CRC32(const uint8_t *pBuffer, uint32_t bufferSize)
     }
 
     Data ^= 0xFFFFFFFF;
+
+    periph_unlock();
 
     return Data;
 }

--- a/user/tests/wiring/no_fixture/concurrent.cpp
+++ b/user/tests/wiring/no_fixture/concurrent.cpp
@@ -20,6 +20,8 @@
 #include "application.h"
 #include "unit-test/unit-test.h"
 
+#if PLATFORM_THREADING
+
 #if PLATFORM_ID == 6
 
 // Regression test for the WICED deadlock in sys_sem_new
@@ -52,4 +54,37 @@ test(CONCURRENT_01_semaphore_deadlock)
     allocatorThread.dispose();
 }
 
-#endif
+#endif // PLATFORM_ID == 6
+
+test(CONCURRENT_02_crc32_is_thread_safe) {
+    const unsigned TEST_DURATION = 1000; // 1 second
+    const size_t DATA_SIZE = 1024;
+    // Allocate a buffer and fill it with random data
+    std::unique_ptr<uint8_t[]> data(new uint8_t[DATA_SIZE]);
+    for (size_t i = 0; i < DATA_SIZE; ++i) {
+        data[i] = random(256);
+    }
+    const uint32_t validCrc = HAL_Core_Compute_CRC32(data.get(), DATA_SIZE);
+    // Spawn a couple of threads doing parallel CRC computations
+    bool ok = false;
+    system_tick_t timeStart = 0;
+    const auto threadFn = [&]() {
+        do {
+            const uint32_t crc = HAL_Core_Compute_CRC32(data.get(), DATA_SIZE);
+            if (crc != validCrc) {
+                ok = false;
+                break;
+            }
+        } while (millis() - timeStart < TEST_DURATION);
+    };
+    ok = true;
+    timeStart = millis();
+    Thread thread1("thread1", threadFn);
+    Thread thread2("thread2", threadFn);
+    // Wait until the threads finish
+    thread1.join();
+    thread2.join();
+    assertTrue(ok);
+}
+
+#endif // PLATFORM_THREADING


### PR DESCRIPTION
### Problem

The CRC peripheral is not thread-safe and thus concurrent hardware-accelerated CRC calculations should be serialized. 

While there's no evidence that the system and application threads perform CRC calculations concurrently, a synthetic test shows that such a situation can cause invalidation of the DCT.

### Solution

Guard the platform's `Compute_CRC32()` function with a global lock.

### Steps to Test

- `wiring/no_fixture`: `CONCURRENT_02*`

### References

- [CH10651]

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)