### PR TITLE
Electron: moves some newlib functions into part1

### DIFF
--- a/modules/electron/system-part1/src/export_services2.c
+++ b/modules/electron/system-part1/src/export_services2.c
@@ -1,3 +1,3 @@
 #define DYNALIB_EXPORT
-#include "printf_float.h"
+#include "printf_export.h"
 #include "services2_dynalib.h"

--- a/services/inc/printf_export.h
+++ b/services/inc/printf_export.h
@@ -54,6 +54,13 @@ _printf_float (struct _reent *data,
                 _CONST char *, size_t len),
            va_list *ap);
 
+int
+_printf_i (struct _reent *data, struct _prt_data_t *pdata, FILE *fp,
+     int (*pfunc)(struct _reent *, FILE *, _CONST char *, size_t len),
+     va_list *ap);
+
+int _svfprintf_r(struct _reent *, FILE *, const char *, va_list) _ATTRIBUTE ((__format__ (__printf__, 3, 0)));
+
 #ifdef __cplusplus
 }
 #endif

--- a/services/inc/services2_dynalib.h
+++ b/services/inc/services2_dynalib.h
@@ -5,7 +5,22 @@
 
 #ifdef DYNALIB_EXPORT
 #include "nanopb_misc.h"
+#include "printf_export.h"
 #include <stdint.h>
+#include <time.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+void _tzset_unlocked_r(struct _reent*);
+unsigned long __udivmoddi4 (unsigned long a, unsigned long b, unsigned long *c);
+int __ssvfscanf_r(struct _reent *r, FILE *f, const char *fmt, va_list va);
+
+#ifdef __cplusplus
+}
+#endif // __cplusplus
+
 #ifdef PB_WITHOUT_64BIT
 #define pb_int64_t int32_t
 #define pb_uint64_t uint32_t
@@ -36,7 +51,13 @@ DYNALIB_FN(12, services2, pb_encode_string, bool(pb_ostream_t*, const pb_byte_t*
 DYNALIB_FN(13, services2, pb_encode_tag, bool(pb_ostream_t*, pb_wire_type_t, uint32_t))
 DYNALIB_FN(14, services2, pb_encode_varint, bool(pb_ostream_t*, pb_uint64_t))
 
-DYNALIB_FN(15, services, _printf_float, int(struct _reent*, struct _prt_data_t*, FILE*, int(*pfunc)(struct _reent* , FILE*, const char*, size_t), va_list*))
+DYNALIB_FN(15, services2, _printf_float, int(struct _reent*, struct _prt_data_t*, FILE*, int(*pfunc)(struct _reent* , FILE*, const char*, size_t), va_list*))
+DYNALIB_FN(16, services2, _tzset_unlocked_r, void(struct _reent*))
+DYNALIB_FN(17, services2, __udivmoddi4, unsigned long(unsigned long, unsigned long, unsigned long*))
+DYNALIB_FN(18, services2, mktime, time_t(struct tm*))
+DYNALIB_FN(19, services2, __ssvfscanf_r, int(struct _reent*, FILE*, const char*, va_list))
+DYNALIB_FN(20, services2, _printf_i, int(struct _reent*, struct _prt_data_t*, FILE*, int (*pfunc)(struct _reent *, FILE *, _CONST char *, size_t), va_list*))
+DYNALIB_FN(21, services2, localtime_r, struct tm*(const time_t*, struct tm*))
 
 DYNALIB_END(services2)
 

--- a/services/src/services_dynalib.c
+++ b/services/src/services_dynalib.c
@@ -29,5 +29,5 @@
 #include "system_error.h"
 #include "led_service.h"
 #include "diagnostics.h"
-#include "printf_float.h"
+#include "printf_export.h"
 #include "services_dynalib.h"


### PR DESCRIPTION
### Problem

Some things can be moved out of Electron system-part3 (module index 2) to free up flash space there. See also #1469.

### Solution

- Export `_tzset_unlocked_r`, `__udivmoddi4`, `mktime`, `__ssvfscanf_r`, `_printf_i`, `localtime_r`

### Results

#### This branch
```
   text	   data	    bss	    dec	    hex	filename
  72932	    556	   2588	  76076	  1292c	../../../build/target/system-part1/platform-10-m/system-part1.elf
   text	   data	    bss	    dec	    hex	filename
 117932	    216	    564	 118712	  1cfb8	../../../build/target/system-part2/platform-10-m/system-part2.elf
   text	   data	    bss	    dec	    hex	filename
 115404	   2700	   3988	 122092	  1dcec	../../../build/target/system-part3/platform-10-m/system-part3.elf
   text	   data	    bss	    dec	    hex	filename
   3708	    108	   1468	   5284	   14a4	../../../build/target/user-part/platform-10-m/blank.elf
```

#### develop

```
   text	   data	    bss	    dec	    hex	filename
  66308	    480	   2548	  69336	  10ed8	../../../build/target/system-part1/platform-10-m/system-part1.elf
   text	   data	    bss	    dec	    hex	filename
 118676	    216	    564	 119456	  1d2a0	../../../build/target/system-part2/platform-10-m/system-part2.elf
   text	   data	    bss	    dec	    hex	filename
 122500	   2776	   4028	 129304	  1f918	../../../build/target/system-part3/platform-10-m/system-part3.elf
   text	   data	    bss	    dec	    hex	filename
   3708	    108	   1468	   5284	   14a4	../../../build/target/user-part/platform-10-m/blank.elf
```

### References

- #1469
- [CH10790]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
