### PR TITLE
Documents low level USB request completion notifications

### DIFF
--- a/platform/MCU/STM32F2xx/STM32_USB_Device_Driver/inc/usbd_def.h
+++ b/platform/MCU/STM32F2xx/STM32_USB_Device_Driver/inc/usbd_def.h
@@ -103,6 +103,8 @@
 #define USB_FEATURE_REMOTE_WAKEUP                          1
 #define USB_FEATURE_TEST_MODE                              2
 
+#define USB_REQ_DATA_STAGE_COMPLETED                       1
+
 /**
   * @}
   */

--- a/platform/MCU/STM32F2xx/STM32_USB_Device_Driver/src/usbd_core.c
+++ b/platform/MCU/STM32F2xx/STM32_USB_Device_Driver/src/usbd_core.c
@@ -241,7 +241,8 @@ static uint8_t USBD_DataOutStage(USB_OTG_CORE_HANDLE *pdev , uint8_t epnum)
         if (pdev->dev.usr_cb && pdev->dev.usr_cb->ControlRequest &&
             (pdev->dev.device_status == USB_OTG_CONFIGURED))
         {
-          ret = pdev->dev.usr_cb->ControlRequest(NULL, 1);
+          // Notify that a Host->Device request with data stage has completed
+          ret = pdev->dev.usr_cb->ControlRequest(NULL, USB_REQ_DATA_STAGE_COMPLETED);
         }
 
         if(ret != USBD_OK && (pdev->dev.class_cb->EP0_RxReady != NULL)&&
@@ -305,7 +306,8 @@ static uint8_t USBD_DataInStage(USB_OTG_CORE_HANDLE *pdev , uint8_t epnum)
           if (pdev->dev.usr_cb && pdev->dev.usr_cb->ControlRequest &&
               (pdev->dev.device_status == USB_OTG_CONFIGURED))
           {
-            ret = pdev->dev.usr_cb->ControlRequest(NULL, 1);
+            // Notify that a Device->Host request with data stage has completed
+            ret = pdev->dev.usr_cb->ControlRequest(NULL, USB_REQ_DATA_STAGE_COMPLETED);
           }
 
           if(ret != USBD_OK && (pdev->dev.class_cb->EP0_TxSent != NULL)&&

--- a/platform/MCU/STM32F2xx/STM32_USB_Device_Driver/src/usbd_req.c
+++ b/platform/MCU/STM32F2xx/STM32_USB_Device_Driver/src/usbd_req.c
@@ -152,6 +152,7 @@ USBD_Status  USBD_StdDevReq (USB_OTG_CORE_HANDLE  *pdev, USB_SETUP_REQ  *req)
   {
     if (pdev->dev.usr_cb && pdev->dev.usr_cb->ControlRequest)
     {
+      // Handle vendor request
       ret = pdev->dev.usr_cb->ControlRequest(req, 0);
       if ((req->wLength == 0) && (ret == USBD_OK))
       {


### PR DESCRIPTION
### Solution

Documents low level USB request completion notifications as suggested in #1406. Replaces literal `1` with `USB_REQ_DATA_STAGE_COMPLETED` for better readability.

### References

- #1406
- [CH10790]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
