### PR TITLE
Fixes some 0.8.0-rc.2 tests

### DIFF
--- a/hal/src/electron/FreeRTOSConfig.h
+++ b/hal/src/electron/FreeRTOSConfig.h
@@ -143,6 +143,7 @@ to exclude the API function. */
 #define INCLUDE_vTaskSuspend			1
 #define INCLUDE_vTaskDelayUntil			1
 #define INCLUDE_vTaskDelay				1
+#define INCLUDE_eTaskGetState			1
 
 /* This is the raw value as per the Cortex-M3 NVIC.  Values can be 255
 (lowest) to 0 (1?) (highest). */

--- a/hal/src/electron/rtos/FreeRTOSv8.2.2/FreeRTOS/Source/tasks.c
+++ b/hal/src/electron/rtos/FreeRTOSv8.2.2/FreeRTOS/Source/tasks.c
@@ -1031,7 +1031,7 @@ StackType_t *pxTopOfStack;
 			#endif
 
 			#if ( INCLUDE_vTaskDelete == 1 )
-				else if( pxStateList == &xTasksWaitingTermination )
+				else if( pxStateList == &xTasksWaitingTermination || pxTCB->pxStack == NULL)
 				{
 					/* The task being queried is referenced from the deleted
 					tasks list. */
@@ -3339,6 +3339,7 @@ TCB_t *pxNewTCB;
 			vPortFreeAligned( pxTCB->pxStack );
 		}
 		#endif
+		pxTCB->pxStack = NULL;
 
 		vPortFree( pxTCB );
 	}

--- a/hal/src/stm32f2xx/concurrent_hal.cpp
+++ b/hal/src/stm32f2xx/concurrent_hal.cpp
@@ -139,7 +139,11 @@ os_result_t os_thread_join(os_thread_t thread)
     }
     return 0;
 #else
-    return -1;
+    while (eTaskGetState(thread) != eDeleted)
+    {
+        HAL_Delay_Milliseconds(10);
+    }
+    return 0;
 #endif
 }
 

--- a/wiring/inc/spark_wiring_fuel.h
+++ b/wiring/inc/spark_wiring_fuel.h
@@ -50,16 +50,13 @@ namespace detail {
 }
 
 class FuelGauge {
-  private: 
-  
-	TwoWire *_i2c = NULL;
-	
-  public:
-
+public:
     FuelGauge(bool _lock = false);
+    FuelGauge(TwoWire& i2c, bool _lock = false);
     ~FuelGauge();
-    boolean begin();				// will assume Wire3 for Electron, otherwise Wire
-	boolean begin(TwoWire & i2c);	// for dedicated selection of I2C interface
+
+    boolean begin();
+
     float getVCell();
     float getSoC();
     float getNormalizedSoC();
@@ -77,12 +74,13 @@ class FuelGauge {
     bool lock();
     bool unlock();
 
-  private:
+private:
 
     void readConfigRegister(byte &MSB, byte &LSB);
     void readRegister(byte startAddress, byte &MSB, byte &LSB);
     void writeRegister(byte address, byte MSB, byte LSB);
 
+    TwoWire& i2c_;
     bool lock_;
 };
 


### PR DESCRIPTION
<details>
  <summary><i>submission notes</i></summary>

```
**Important:** Please sanitize/remove any confidential info like usernames, passwords, org names, product names/ids, access tokens, client ids/secrets, or anything else you don't wish to share.

Please Read and Sign the Contributor License Agreement ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md)).

You may also delete this submission notes header if you'd like. Thank you for contributing!
```
</details>

### Problem

1. Cellular band select tests should be performed while deregistered from the network, otherwise current RAT affects a selection of bands available. See *7.22 Select band +UBANDSEL* documentation from u-blox Cellular Modules - AT Commands Manual:

```
TOBY-L2 / MPCI-L2 / LARA-R2 / TOBY-R2 / SARA-U2 / LISA-U2 / LISA-U1
The list of supported bands presents exclusively GSM, UMTS or LTE bands depending on which RAT the
MT is currently registered. If it is not registered, the bands presented depend on +URAT command:
• If in single mode, depends on <AcT>
• If in dual mode, depends on <PreferredAct>
```

2. `CONCURRENT_02_crc32_is_thread_safe` causes a hardfault due to `os_thread_join()` not working on Electron.
3. #1297 broke system power management and diagnostics by introducing a requirement to call previously non-existent `begin()` method. This change will break user applications as well.

### Solution

1. Perform `AT+COPS=2` before executing band select tests
2. Implement `os_thread_join()` for Electron
3. Remove the requirement to call `FuelGauge::begin()` and add a constructor overload that takes a `TwoWire` instead of `begin()` method.

### Steps to Test

- `wiring/no_fixture`

### Example App

N/A

### References

- [CH10790]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
