### PR TITLE
heap upperbound overlaps system-part1 (module index 3) static RAM

### DIFF
--- a/modules/electron/system-part3/module_system_part2_export.ld
+++ b/modules/electron/system-part3/module_system_part2_export.ld
@@ -51,7 +51,7 @@ system_part2_ram_end = stack_start;
 system_heap_end = system_part3_ram_start;
 
 ASSERT ( system_part2_ram_start == system_part3_ram_end, "electron system part3 static ram should come immediately before system part2 static ram" ) ;
-
+ASSERT ( (link_heap_location_end <= system_part3_ram_start), "the heap should come immediately before part3 static ram") ;
 
 PROVIDE ( dynalib_location_hal = system_part2_module_table + 0 );
 PROVIDE ( dynalib_location_rt = system_part2_module_table + 4 );

--- a/modules/shared/stm32f2xx/part2.ld
+++ b/modules/shared/stm32f2xx/part2.ld
@@ -72,8 +72,7 @@ SECTIONS
 
     /* Heap comes immediately after system-part1 */
     link_heap_location = ALIGN(system_part1_module_ram_end, 4);
-
-    link_heap_location_end = ORIGIN(SRAM);
+    link_heap_location_end = system_heap_end;
 
     padding_length = ALIGN(system_part2_ram_start - ORIGIN(SRAM), 512);
 


### PR DESCRIPTION
### Problem

SYSTEM_07_* memory stress test was failing on the Electron. This was because the heap extended into the region of static RAM for system-part1 (module index 3).

There were no assertions for the symbol `link_heap_location_end` and so this issue went undetected at build time.

### Solution

Move the upper bound of the heap to before the static RAM block.  The symbol `system_heap_end` was already pointing to the correct location. 

### Steps to Test

`SYSTEM_07*` in `wiring/no_fixture`

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)