### PR TITLE
adds UPSV handling to cellular_hal

### DIFF
--- a/hal/inc/cellular_hal.h
+++ b/hal/inc/cellular_hal.h
@@ -163,6 +163,13 @@ int cellular_lock(void* reserved);
  */
 void cellular_unlock(void* reserved);
 
+/**
+ * Sets the power mode used, bound to 0-3.
+ *
+ * mode is volatile and will default to 1 on system reset/boot.
+ */
+void cellular_set_power_mode(int mode, void* reserved);
+
 #ifdef __cplusplus
 }
 #endif

--- a/hal/inc/hal_dynalib_cellular.h
+++ b/hal/inc/hal_dynalib_cellular.h
@@ -70,6 +70,7 @@ DYNALIB_FN(29, hal_cellular, cellular_imsi_to_network_provider, cellular_result_
 DYNALIB_FN(30, hal_cellular, cellular_network_provider_data_get, const CellularNetProvData(void*))
 DYNALIB_FN(31, hal_cellular, cellular_lock, int(void*))
 DYNALIB_FN(32, hal_cellular, cellular_unlock, void(void*))
+DYNALIB_FN(33, hal_cellular, cellular_set_power_mode, void(int mode, void* reserved))
 DYNALIB_END(hal_cellular)
 
 #endif  // PLATFORM_ID == 10

--- a/hal/src/electron/cellular_hal.cpp
+++ b/hal/src/electron/cellular_hal.cpp
@@ -329,4 +329,11 @@ void cellular_unlock(void* reserved)
     electronMDM.unlock();
 }
 
+void cellular_set_power_mode(int mode, void* reserved)
+{
+    if (mode >= 0 && mode <= 3) {
+        electronMDM.setPowerMode(mode);
+    }
+}
+
 #endif // !defined(HAL_CELLULAR_EXCLUDE)

--- a/hal/src/electron/modem/mdm_hal.h
+++ b/hal/src/electron/modem/mdm_hal.h
@@ -46,6 +46,9 @@ public:
     //! get static instance
     static MDMParser* getInstance() { return inst; };
 
+    /* Used to set the power mode used in MDMParser::init() */
+    void setPowerMode(int mode);
+
     /* Used to cancel all operations */
     void cancel(void);
 
@@ -578,6 +581,7 @@ protected:
     bool _activated;
     bool _attached;
     bool _attached_urc;
+    int _power_mode;
     volatile bool _cancel_all_operations;
 #ifdef MDM_DEBUG
     int _debugLevel;


### PR DESCRIPTION
### Problem

No way to change the UPSV level so it doesn't get overridden when system firmware re-initializes the modem.

### Solution

Adds a cellular_hal function to set the UPSV level from 0-3 (default: 1).

### Steps to Test

- Run test app, look for UPSV=0 in logs.
- Comment out cellular_set_power_mode() and look for UPSV=1 in logs.

### Example App

```c
SYSTEM_MODE(SEMI_AUTOMATIC);
SerialLogHandler logHandler(LOG_LEVEL_ALL);

void setup() {
  cellular_set_power_mode(0, NULL);
  Particle.connect();
}

```

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [N/A] Run unit/integration/application tests on device
- [N/A] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
