### PR TITLE
[Photon/Electron] WKP pin needs to be disabled as a wakeup source on boot to allow its normal operation

### DIFF
--- a/hal/src/stm32f2xx/core_hal_stm32f2xx.c
+++ b/hal/src/stm32f2xx/core_hal_stm32f2xx.c
@@ -333,6 +333,8 @@ void HAL_Core_Config(void)
 
     RCC_AHB1PeriphClockCmd(RCC_AHB1Periph_BKPSRAM, ENABLE);
 
+    /* Disable WKP pin */
+    PWR_WakeUpPinCmd(DISABLE);
 
     //Wiring pins default to inputs
 #if !defined(USE_SWD_JTAG) && !defined(USE_SWD)

--- a/user/tests/wiring/sleep/sleep.cpp
+++ b/user/tests/wiring/sleep/sleep.cpp
@@ -20,6 +20,22 @@ test(sleep_0_device_wakes_from_deep_sleep_with_short_sleep_time)
         magick = 0;
         // We should have woken up from deep sleep
         assertEqual(System.resetReason(), (int)RESET_REASON_POWER_MANAGEMENT);
+
+        /**
+         * Issue #1447 "WKP/A7 ignores pinMode after waking from deep sleep"
+         * A7/WKP pin must be jumpered to D7 because
+         * digitalWrite(A7) will be equal to digitalRead(A7) despite this issue.
+         */
+        Serial.println("SETUP: Make sure to jumper A7/WKP pin to D7 pin.");
+        pinMode(A7, OUTPUT);
+        pinMode(D7, INPUT);
+        digitalWrite(A7, HIGH);
+        delay(1);
+        assertEqual((int)digitalRead(D7), (int)HIGH);
+        digitalWrite(A7, LOW);
+        delay(1);
+        assertEqual((int)digitalRead(D7), (int)LOW);
+        // Issue #1447
     } else {
         Serial.println("Publishing 10 messages, see them at 'particle subscribe mine'");
         // Set magic key in retained memory to indicate that we just went into deep sleep


### PR DESCRIPTION
### Problem

See #1447

### Solution

Call `PWR_WakeUpPinCmd(DISABLE);` on boot to allow normal WKP/A7 pin operation.

### Steps to Test

N/A

### Example App

```c++
static system_tick_t last = 0;

void setup() {
    pinMode(A7, OUTPUT);
}

void loop() {
    if (Serial.available() > 0) {
        System.sleep(SLEEP_MODE_DEEP, 30);
    }

    if (millis() - last > 1000) {
        digitalWrite(A7, !digitalRead(A7));
        last = millis();
    }
}
```

1. Connect WKP to D7
2. Run the app, D7 should be blinking at 1Hz
3. Connect via serial to the device, send any character
4. The device should go into deep sleep for 30 seconds
5. After waking up it should continue blinking D7 at 1Hz

### References

- Closes #1447

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
