### PR TITLE
[Photon/P1/Electron] Recursive logging freezes the application thread while the LogHandler is trying to acquire a lock on the resource.

### DIFF
--- a/user/tests/wiring/no_fixture/logging.cpp
+++ b/user/tests/wiring/no_fixture/logging.cpp
@@ -32,7 +32,8 @@ public:
     void logMessage(const char *msg, LogLevel level, const char *category, const LogAttributes &attr)
     {
         if (active) {
-            // Fail if we are allowed to re-enter this logging handler, as the count won't increase
+            // Fail if we are allowed to re-enter this logging handler,
+            // as the count won't increase to 10.  It will remain pinned to 5.
             count--;
             return;
         }
@@ -40,7 +41,7 @@ public:
 
         // Serial.printlnf("logMessage: %d", count); // DEBUG
         if (count++ >= 5) {
-            Log.info("force re-entry into this logMessage function");
+            Log.info("attempt re-entry into this logMessage function: %d", count); // DEBUG
         }
 
         active = false;
@@ -64,4 +65,27 @@ test(LOGGING_01_recursive_log_handling)
     }
     recursiveLogger.removeHandler();
     assertEqual(recursiveLogger.getCount(), 10);
+}
+test(LOGGING_02_multiple_recursive_log_handling)
+{
+    Serial.println("IF THIS HANGS HERE, THE TEST FAILED!");
+    RecursiveLogger recursiveLogger1;
+    RecursiveLogger recursiveLogger2;
+    RecursiveLogger recursiveLogger3;
+    RecursiveLogger recursiveLogger4;
+    recursiveLogger1.addHandler();
+    recursiveLogger2.addHandler();
+    recursiveLogger3.addHandler();
+    recursiveLogger4.addHandler();
+    for (int x=0; x<10; x++) {
+        Log.info("recursive logging %lu", millis());
+    }
+    recursiveLogger1.removeHandler();
+    recursiveLogger2.removeHandler();
+    recursiveLogger3.removeHandler();
+    recursiveLogger4.removeHandler();
+    assertEqual(recursiveLogger1.getCount(), 10);
+    assertEqual(recursiveLogger2.getCount(), 10);
+    assertEqual(recursiveLogger3.getCount(), 10);
+    assertEqual(recursiveLogger4.getCount(), 10);
 }

--- a/user/tests/wiring/no_fixture/logging.cpp
+++ b/user/tests/wiring/no_fixture/logging.cpp
@@ -1,0 +1,67 @@
+
+#include "application.h"
+#include "unit-test/unit-test.h"
+
+class RecursiveLogger : LogHandler
+{
+private:
+
+    volatile bool active;
+    int count;
+
+public:
+
+    RecursiveLogger(LogLevel level = LOG_LEVEL_INFO) : LogHandler(level)
+    {
+        active = false;
+        count = 0;
+    }
+
+    void addHandler() {
+        LogManager::instance()->addHandler(this);
+    }
+
+    void removeHandler() {
+        LogManager::instance()->removeHandler(this);
+    }
+
+    int getCount() {
+        return count;
+    }
+
+    void logMessage(const char *msg, LogLevel level, const char *category, const LogAttributes &attr)
+    {
+        if (active) {
+            // Fail if we are allowed to re-enter this logging handler, as the count won't increase
+            count--;
+            return;
+        }
+        active = true;
+
+        // Serial.printlnf("logMessage: %d", count); // DEBUG
+        if (count++ >= 5) {
+            Log.info("force re-entry into this logMessage function");
+        }
+
+        active = false;
+    }
+};
+
+// SerialLogHandler logHandler(LOG_LEVEL_ALL);  // DEBUG
+
+/**
+ * This tests two things related to Issue #1497: https://github.com/particle-iot/firmware/issues/1497
+ * 1) that the application thread doesn't lock up waiting for a logger mutex to clear
+ * 2) that the logMessage function isn't allowed to be called in a recursive manner
+ */
+test(LOGGING_01_recursive_log_handling)
+{
+    Serial.println("IF THIS HANGS HERE, THE TEST FAILED!");
+    RecursiveLogger recursiveLogger;
+    recursiveLogger.addHandler();
+    for (int x=0; x<10; x++) {
+        Log.info("recursive logging %lu", millis());
+    }
+    recursiveLogger.removeHandler();
+    assertEqual(recursiveLogger.getCount(), 10);
+}

--- a/wiring/inc/spark_wiring_logging.h
+++ b/wiring/inc/spark_wiring_logging.h
@@ -577,7 +577,7 @@ private:
 
     Vector<LogHandler*> activeHandlers_;
 
-    volatile bool output_active_;
+    bool outputActive_;
 
 #if Wiring_LogConfig
     Vector<FactoryHandler> factoryHandlers_;

--- a/wiring/inc/spark_wiring_logging.h
+++ b/wiring/inc/spark_wiring_logging.h
@@ -577,6 +577,8 @@ private:
 
     Vector<LogHandler*> activeHandlers_;
 
+    volatile bool output_active_;
+
 #if Wiring_LogConfig
     Vector<FactoryHandler> factoryHandlers_;
     LogHandlerFactory *handlerFactory_;
@@ -584,7 +586,7 @@ private:
 #endif
 
 #if PLATFORM_THREADING
-    Mutex mutex_; // TODO: Use read-write lock?
+    RecursiveMutex mutex_; // TODO: Use read-write lock?
 #endif
 
     // This class can be instantiated only via instance() method
@@ -602,6 +604,9 @@ private:
     static void logMessage(const char *msg, int level, const char *category, const LogAttributes *attr, void *reserved);
     static void logWrite(const char *data, size_t size, int level, const char *category, void *reserved);
     static int logEnabled(int level, const char *category, void *reserved);
+
+    bool isActive() const;
+    void setActive(bool output_active);
 };
 
 #if Wiring_LogConfig

--- a/wiring/src/spark_wiring_logging.cpp
+++ b/wiring/src/spark_wiring_logging.cpp
@@ -674,7 +674,7 @@ spark::LogManager::LogManager() {
     handlerFactory_ = DefaultLogHandlerFactory::instance();
     streamFactory_ = DefaultOutputStreamFactory::instance();
 #endif
-    output_active_ = false;
+    outputActive_ = false;
 }
 
 spark::LogManager::~LogManager() {
@@ -892,11 +892,11 @@ int spark::LogManager::logEnabled(int level, const char *category, void *reserve
 }
 
 inline bool spark::LogManager::isActive() const {
-    return output_active_;
+    return outputActive_;
 }
 
-inline void spark::LogManager::setActive(bool output_active) {
-    output_active_ = output_active;
+inline void spark::LogManager::setActive(bool outputActive) {
+    outputActive_ = outputActive;
 }
 
 #if Wiring_LogConfig

--- a/wiring/src/spark_wiring_logging.cpp
+++ b/wiring/src/spark_wiring_logging.cpp
@@ -674,6 +674,7 @@ spark::LogManager::LogManager() {
     handlerFactory_ = DefaultLogHandlerFactory::instance();
     streamFactory_ = DefaultOutputStreamFactory::instance();
 #endif
+    output_active_ = false;
 }
 
 spark::LogManager::~LogManager() {
@@ -839,9 +840,15 @@ void spark::LogManager::logMessage(const char *msg, int level, const char *categ
 #endif
     LogManager *that = instance();
     LOG_WITH_LOCK(that->mutex_) {
+        // prevent re-entry
+        if (that->isActive()) {
+            return;
+        }
+        that->setActive(true);
         for (LogHandler *handler: that->activeHandlers_) {
             handler->message(msg, (LogLevel)level, category, *attr);
         }
+        that->setActive(false);
     }
 }
 
@@ -853,9 +860,15 @@ void spark::LogManager::logWrite(const char *data, size_t size, int level, const
 #endif
     LogManager *that = instance();
     LOG_WITH_LOCK(that->mutex_) {
+        // prevent re-entry
+        if (that->isActive()) {
+            return;
+        }
+        that->setActive(true);
         for (LogHandler *handler: that->activeHandlers_) {
             handler->write(data, size, (LogLevel)level, category);
         }
+        that->setActive(false);
     }
 }
 
@@ -876,6 +889,14 @@ int spark::LogManager::logEnabled(int level, const char *category, void *reserve
         }
     }
     return (level >= minLevel);
+}
+
+inline bool spark::LogManager::isActive() const {
+    return output_active_;
+}
+
+inline void spark::LogManager::setActive(bool output_active) {
+    output_active_ = output_active;
 }
 
 #if Wiring_LogConfig


### PR DESCRIPTION
### Problem

Recursive logging freezes the application thread while the LogHandler is trying to acquire a lock on the resource (#1497).

### Solution

1. Use a `RecursiveMutex` in `spark_wiring_logging.h`
2. Prevent re-entry into subclassed `logHandler` functions `logMessage` and `logWrite` from the `LogManager` instance

### Steps to Test

Run `TEST=wiring/no_fixture`

### References

- Closes #1497

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [x] Added to CHANGELOG.md after merging (add links to docs and issues)
