### PR TITLE
Wait for Wiring Thread to start

### DIFF
--- a/user/tests/wiring/api/thread.cpp
+++ b/user/tests/wiring/api/thread.cpp
@@ -17,8 +17,10 @@ test(api_thread) {
     Thread t;
     API_COMPILE(t.dispose());
     API_COMPILE(t.join());
-    API_COMPILE(t.is_valid());
-    API_COMPILE(t.is_current());
+    API_COMPILE(t.isValid());
+    API_COMPILE(t.isCurrent());
+    API_COMPILE(t.is_valid()); // Deprecated
+    API_COMPILE(t.is_current()); // Deprecated
     API_COMPILE(t = Thread("test", thread_fn));
 }
 

--- a/user/tests/wiring/no_fixture/thread.cpp
+++ b/user/tests/wiring/no_fixture/thread.cpp
@@ -6,11 +6,12 @@
 
 static uint32_t s_ram_free_before = 0;
 
+Thread testThread;
 test(THREAD_01_creation)
 {
-	s_ram_free_before = System.freeMemory();
+    s_ram_free_before = System.freeMemory();
     volatile bool threadRan = false;
-    Thread testThread = Thread("test", [&]() {
+    testThread = Thread("test", [&]() {
         threadRan = true;
     }, OS_THREAD_PRIORITY_DEFAULT, 4096);
 

--- a/wiring/inc/spark_wiring_thread.h
+++ b/wiring/inc/spark_wiring_thread.h
@@ -81,6 +81,8 @@ private:
         }
     };
 
+    // The thread context is allocated dynamically in order to keep all pointers to it valid, even if
+    // the original wrapper object has been moved and subsequently destroyed
     std::unique_ptr<Data> d_;
 
 public:

--- a/wiring/inc/spark_wiring_thread.h
+++ b/wiring/inc/spark_wiring_thread.h
@@ -31,6 +31,7 @@
 #include <mutex>
 #include <functional>
 #include <type_traits>
+#include <memory>
 
 typedef std::function<os_thread_return_t(void)> wiring_thread_fn_t;
 
@@ -63,35 +64,75 @@ public:
 class Thread
 {
 private:
-    mutable os_thread_t handle = OS_THREAD_INVALID_HANDLE;
-    mutable wiring_thread_fn_t *wrapper = NULL;
-    os_thread_fn_t func_ = NULL;
-    void* func_param_ = NULL;
-    bool started_ = false;
-    bool exited_ = false;
+    struct Data {
+        std::unique_ptr<wiring_thread_fn_t> wrapper;
+        os_thread_t handle;
+        os_thread_fn_t func;
+        void* func_param;
+        volatile bool started;
+        volatile bool exited;
+
+        Data() :
+            handle(OS_THREAD_INVALID_HANDLE),
+            func(nullptr),
+            func_param(nullptr),
+            started(false),
+            exited(false) {
+        }
+    };
+
+    std::unique_ptr<Data> d_;
 
 public:
-    Thread() : handle(OS_THREAD_INVALID_HANDLE) {}
+    Thread()
+    {
+    }
 
     Thread(const char* name, os_thread_fn_t function, void* function_param=NULL,
             os_thread_prio_t priority=OS_THREAD_PRIORITY_DEFAULT, size_t stack_size=OS_THREAD_STACK_SIZE_DEFAULT)
-        : wrapper(NULL),
-          func_(function),
-          func_param_(function_param)
+        : d_(new(std::nothrow) Data)
     {
-        os_thread_create(&handle, name, priority, &Thread::run, this, stack_size);
-        while (!started_) os_thread_yield();
+        if (!d_) {
+            goto error;
+        }
+        d_->func = function;
+        d_->func_param = function_param;
+        if (os_thread_create(&d_->handle, name, priority, &Thread::run, d_.get(), stack_size) != 0) {
+            goto error;
+        }
+        while (!d_->started) {
+            os_thread_yield();
+        }
+        return;
+    error:
+        d_.reset();
     }
 
     Thread(const char *name, wiring_thread_fn_t function,
             os_thread_prio_t priority=OS_THREAD_PRIORITY_DEFAULT, size_t stack_size=OS_THREAD_STACK_SIZE_DEFAULT)
-        : handle(OS_THREAD_INVALID_HANDLE), wrapper(NULL)
+        : d_(new(std::nothrow) Data)
     {
-        if(function) {
-            wrapper = new wiring_thread_fn_t(function);
-            os_thread_create(&handle, name, priority, &Thread::run, this, stack_size);
-            while (!started_) os_thread_yield();
+        if (!d_) {
+            goto error;
         }
+        d_->wrapper.reset(new(std::nothrow) wiring_thread_fn_t(std::move(function)));
+        if (!d_->wrapper) {
+            goto error;
+        }
+        if (os_thread_create(&d_->handle, name, priority, &Thread::run, d_.get(), stack_size) != 0) {
+            goto error;
+        }
+        while (!d_->started) {
+            os_thread_yield();
+        }
+        return;
+    error:
+        d_.reset();
+    }
+
+    Thread(Thread&& thread)
+        : d_(std::move(thread.d_))
+    {
     }
 
     ~Thread()
@@ -101,74 +142,70 @@ public:
 
     void dispose()
     {
-        if (!is_valid())
+        if (!isValid())
             return;
 
         // We shouldn't dispose of current thread
-        if (is_current())
+        if (isCurrent())
             return;
 
-        if (!exited_) {
+        if (!d_->exited) {
             join();
         }
 
-        if (wrapper) {
-            delete wrapper;
-            wrapper = NULL;
-        }
+        os_thread_cleanup(d_->handle);
 
-        os_thread_cleanup(handle);
-        handle = OS_THREAD_INVALID_HANDLE;
+        d_.reset();
     }
 
     bool join()
     {
-        return is_valid() && os_thread_join(handle)==0;
+        return isValid() && os_thread_join(d_->handle)==0;
     }
 
     bool cancel()
     {
-        return is_valid() && os_thread_exit(handle)==0;
+        return isValid() && os_thread_exit(d_->handle)==0;
     }
 
-    bool is_valid()
+    bool is_valid() // Deprecated
+    {
+        return isValid();
+    }
+
+    bool isValid() const
     {
         // TODO should this also check xTaskIsTaskFinished as well?
-        return handle!=OS_THREAD_INVALID_HANDLE;
+        return (bool)d_;
     }
 
-    bool is_current()
+    bool is_current() // Deprecated
     {
-        return os_thread_is_current(handle);
+        return isCurrent();
     }
 
-    Thread& operator = (const Thread& rhs)
+    bool isCurrent() const
     {
-        if (this != &rhs)
-        {
-            this->handle = rhs.handle;
-            this->wrapper = rhs.wrapper;
-            this->func_ = rhs.func_;
-            this->func_param_ = rhs.func_param_;
-            this->exited_ = rhs.exited_;
-            this->started_ = rhs.started_;
-            rhs.handle = OS_THREAD_INVALID_HANDLE;
-            rhs.wrapper = NULL;
-        }
+        return isValid() && os_thread_is_current(d_->handle);
+    }
+
+    Thread& operator=(Thread&& thread)
+    {
+        d_ = std::move(thread.d_);
         return *this;
     }
 
 private:
 
     static os_thread_return_t run(void* param) {
-        Thread* th = (Thread*)param;
-        th->started_ = true;
-        if (th->func_) {
-            (*(th->func_))(th->func_param_);
+        Data* th = (Data*)param;
+        th->started = true;
+        if (th->func) {
+            (*(th->func))(th->func_param);
         } else if (th->wrapper) {
             (*(th->wrapper))();
         }
-        th->exited_ = true;
+        th->exited = true;
         os_thread_exit(nullptr);
     }
 };


### PR DESCRIPTION
Wait for Wiring `Thread` to reach `Thread::run` before returning from the constructor to avoid HardFault crash when the Thread instance is not available anymore.

Fixes #1527. See that issue for details, steps to reproduce and example app.

This is a regression that was introduced in 0.7.0. It should be backported to the 0.7.x line.

### References

- [CH17452]

### Completeness

- [x] User is totes amazing for contributing!
- [X] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [X] Problem and Solution clearly stated
- [X] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
