### PR TITLE
Fixes missing URCs for received data during TX or RX socket operations

### DIFF
--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -1777,7 +1777,7 @@ int MDMParser::socketSend(int socket, const char * buf, int len)
         cnt -= blk;
     }
     LOCK();
-    if (_sockets[socket].pending == 0) {
+    if (ISSOCKET(socket) && (_sockets[socket].pending == 0)) {
         sendFormated("AT+USORD=%d,0\r\n", _sockets[socket].handle); // TCP
         waitFinalResp(NULL, NULL, 10*1000);
     }
@@ -1813,7 +1813,7 @@ int MDMParser::socketSendTo(int socket, MDM_IP ip, int port, const char * buf, i
         cnt -= blk;
     }
     LOCK();
-    if (_sockets[socket].pending == 0) {
+    if (ISSOCKET(socket) && (_sockets[socket].pending == 0)) {
         sendFormated("AT+USORF=%d,0\r\n", _sockets[socket].handle); // UDP
         waitFinalResp(NULL, NULL, 10*1000);
     }
@@ -1921,7 +1921,7 @@ int MDMParser::socketRecv(int socket, char* buf, int len)
         }
     }
     LOCK();
-    if (_sockets[socket].pending == 0) {
+    if (ISSOCKET(socket) && (_sockets[socket].pending == 0)) {
         sendFormated("AT+USORD=%d,0\r\n", _sockets[socket].handle); // TCP
         waitFinalResp(NULL, NULL, 10*1000);
     }
@@ -1995,7 +1995,7 @@ int MDMParser::socketRecvFrom(int socket, MDM_IP* ip, int* port, char* buf, int 
         }
     }
     LOCK();
-    if (_sockets[socket].pending == 0) {
+    if (ISSOCKET(socket) && (_sockets[socket].pending == 0)) {
         sendFormated("AT+USORF=%d,0\r\n", _sockets[socket].handle); // UDP
         waitFinalResp(NULL, NULL, 10*1000);
     }


### PR DESCRIPTION
### Problem

We've been getting reports of times when devices seem to stop being able to receive data.  They seem to recover after the device exhausts its retries (about 78 seconds) and reconnects to the Cloud.  This has been a tricky bug to nail down, but it appears to be a corner case in how the cellular modem reports URCs, or in this case, doesn't report them.

The error condition occurs with the following sequence.  We start with the RX buffer is empty.  We receive some data, and the modem notifies us of this pending data via URC (Unsolicited Response Code). When we go to read that data from the modem, if we received more data concurrently, no further URC is generated after the data is received, or after the read completes.  The error case can occur during a write operation as well (receiving data while we are sending data).  We normally rely on URCs to allow us to receive status from the modem asynchronously and avoid polling it for status, which allows it to enter low power mode as well.

### Solution

After extensive testing it was discovered that a forced poll of the socket (AT+USORF=0,0 for UDP and AT+USORD=0,0 for TCP) after all read and write operations was necessary to mitigate this corner case when we don't receive URCs naturally for received data.

There will be a 40 ms delay to poll the modem for pending data after every packet sent and received.  This cost in time comes with the reward of reliability.

### Steps to Test

- `TEST=wiring/no_fixture`
- Extensive internal testing has shown this fix is very reliable. In general what is needed is a fast echo server to send lots of traffic to the device, and for the device to also echo that data back to the server. The server should also let the device repeatedly catch-up and process all messages so that the RX buffer can start from 0 many times.

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [N/A] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
