### PR TITLE
[Electron] Adds `keepalive_source_t` to infer when Pinger interval should be updated

### DIFF
--- a/communication/src/communication_dynalib.h
+++ b/communication/src/communication_dynalib.h
@@ -68,7 +68,7 @@ DYNALIB_FN(BASE_IDX + 2, communication, extract_public_ec_key, int(uint8_t*, siz
 #define BASE_IDX2 (BASE_IDX + 1)
 #endif
 
-DYNALIB_FN(BASE_IDX2 + 0, communication, spark_protocol_set_connection_property, int(ProtocolFacade*, unsigned, unsigned, particle::protocol::keepalive_source_t, void*))
+DYNALIB_FN(BASE_IDX2 + 0, communication, spark_protocol_set_connection_property, int(ProtocolFacade*, unsigned, unsigned, particle::protocol::connection_properties_t*, void*))
 DYNALIB_FN(BASE_IDX2 + 1, communication, spark_protocol_command, int(ProtocolFacade* protocol, ProtocolCommands::Enum cmd, uint32_t data, void* reserved))
 DYNALIB_FN(BASE_IDX2 + 2, communication, spark_protocol_time_request_pending, bool(ProtocolFacade*, void*))
 DYNALIB_FN(BASE_IDX2 + 3, communication, spark_protocol_time_last_synced, system_tick_t(ProtocolFacade*, time_t*, void*))

--- a/communication/src/communication_dynalib.h
+++ b/communication/src/communication_dynalib.h
@@ -68,8 +68,7 @@ DYNALIB_FN(BASE_IDX + 2, communication, extract_public_ec_key, int(uint8_t*, siz
 #define BASE_IDX2 (BASE_IDX + 1)
 #endif
 
-DYNALIB_FN(BASE_IDX2 + 0, communication, spark_protocol_set_connection_property,
-           int(ProtocolFacade*, unsigned, unsigned, void*, void*))
+DYNALIB_FN(BASE_IDX2 + 0, communication, spark_protocol_set_connection_property, int(ProtocolFacade*, unsigned, unsigned, particle::protocol::keepalive_source_t, void*))
 DYNALIB_FN(BASE_IDX2 + 1, communication, spark_protocol_command, int(ProtocolFacade* protocol, ProtocolCommands::Enum cmd, uint32_t data, void* reserved))
 DYNALIB_FN(BASE_IDX2 + 2, communication, spark_protocol_time_request_pending, bool(ProtocolFacade*, void*))
 DYNALIB_FN(BASE_IDX2 + 3, communication, spark_protocol_time_last_synced, system_tick_t(ProtocolFacade*, time_t*, void*))

--- a/communication/src/ping.h
+++ b/communication/src/ping.h
@@ -9,9 +9,10 @@ class Pinger
 	bool expecting_ping_ack;
 	system_tick_t ping_interval;
 	system_tick_t ping_timeout;
+	keepalive_source_t keepalive_source;
 
 public:
-	Pinger() : expecting_ping_ack(false), ping_interval(0), ping_timeout(10000) {}
+	Pinger() : expecting_ping_ack(false), ping_interval(0), ping_timeout(10000), keepalive_source(KeepAliveSource::SYSTEM) {}
 
 	/**
 	 * Sets the ping interval that the client will send pings to the server, and the expected maximum response time.
@@ -20,11 +21,24 @@ public:
 	{
 		this->ping_interval = interval;
 		this->ping_timeout = timeout;
+		this->keepalive_source = KeepAliveSource::SYSTEM;
 	}
 
-	void set_interval(system_tick_t interval)
+	void set_interval(system_tick_t interval, keepalive_source_t source)
 	{
-		this->ping_interval = interval;
+		/**
+		 * LAST  CURRENT  UPDATE?
+		 * ======================
+		 * SYS   SYS      YES
+		 * SYS   USER     YES
+		 * USER  SYS      NO
+		 * USER  USER     YES
+		 */
+		if ( !(this->keepalive_source == KeepAliveSource::USER && source == KeepAliveSource::SYSTEM) )
+		{
+			this->ping_interval = interval;
+			this->keepalive_source = source;
+		}
 	}
 
 	void reset()

--- a/communication/src/protocol.h
+++ b/communication/src/protocol.h
@@ -292,9 +292,9 @@ public:
 		pinger.init(interval, timeout);
 	}
 
-	void set_keepalive(system_tick_t interval)
+	void set_keepalive(system_tick_t interval, keepalive_source_t source)
 	{
-		pinger.set_interval(interval);
+		pinger.set_interval(interval, source);
 	}
 
 	void set_handlers(CommunicationsHandlers& handlers)

--- a/communication/src/protocol_defs.h
+++ b/communication/src/protocol_defs.h
@@ -120,6 +120,12 @@ enum Enum {
 
 typedef uint32_t keepalive_source_t;
 
+typedef struct
+{
+    uint16_t size;
+    keepalive_source_t keepalive_source;
+} connection_properties_t;
+
 namespace KeepAliveSource {
 enum Enum {
     USER   = 1<<0,   // set by user in wiring

--- a/communication/src/protocol_defs.h
+++ b/communication/src/protocol_defs.h
@@ -118,4 +118,13 @@ enum Enum {
 };
 }
 
+typedef uint32_t keepalive_source_t;
+
+namespace KeepAliveSource {
+enum Enum {
+    USER   = 1<<0,   // set by user in wiring
+    SYSTEM = 1<<1    // set by system
+};
+}
+
 }}

--- a/communication/src/spark_protocol_functions.cpp
+++ b/communication/src/spark_protocol_functions.cpp
@@ -180,12 +180,12 @@ void spark_protocol_get_product_details(ProtocolFacade* protocol, product_detail
 }
 
 int spark_protocol_set_connection_property(ProtocolFacade* protocol, unsigned property_id,
-                                           unsigned data, void* datap, void* reserved)
+                                           unsigned data, particle::protocol::keepalive_source_t source, void* reserved)
 {
     ASSERT_ON_SYSTEM_THREAD();
     if (property_id == particle::protocol::Connection::PING)
     {
-        protocol->set_keepalive(data);
+        protocol->set_keepalive(data, source);
     }
     return 0;
 }
@@ -311,7 +311,7 @@ void spark_protocol_get_product_details(SparkProtocol* protocol, product_details
 }
 
 int spark_protocol_set_connection_property(SparkProtocol* protocol, unsigned property_id,
-                                           unsigned data, void* datap, void* reserved)
+                                           unsigned data, particle::protocol::keepalive_source_t source, void* reserved)
 {
     return 0;
 }

--- a/communication/src/spark_protocol_functions.cpp
+++ b/communication/src/spark_protocol_functions.cpp
@@ -180,12 +180,12 @@ void spark_protocol_get_product_details(ProtocolFacade* protocol, product_detail
 }
 
 int spark_protocol_set_connection_property(ProtocolFacade* protocol, unsigned property_id,
-                                           unsigned data, particle::protocol::keepalive_source_t source, void* reserved)
+                                           unsigned data, particle::protocol::connection_properties_t* conn_prop, void* reserved)
 {
     ASSERT_ON_SYSTEM_THREAD();
     if (property_id == particle::protocol::Connection::PING)
     {
-        protocol->set_keepalive(data, source);
+        protocol->set_keepalive(data, conn_prop->keepalive_source);
     }
     return 0;
 }
@@ -311,7 +311,7 @@ void spark_protocol_get_product_details(SparkProtocol* protocol, product_details
 }
 
 int spark_protocol_set_connection_property(SparkProtocol* protocol, unsigned property_id,
-                                           unsigned data, particle::protocol::keepalive_source_t source, void* reserved)
+                                           unsigned data, particle::protocol::connection_properties_t* conn_prop, void* reserved)
 {
     return 0;
 }

--- a/communication/src/spark_protocol_functions.h
+++ b/communication/src/spark_protocol_functions.h
@@ -178,8 +178,7 @@ void spark_protocol_set_product_id(ProtocolFacade* protocol, product_id_t produc
 void spark_protocol_set_product_firmware_version(ProtocolFacade* protocol, product_firmware_version_t product_firmware_version, unsigned int param=0, void* reserved = NULL);
 void spark_protocol_get_product_details(ProtocolFacade* protocol, product_details_t* product_details, void* reserved=NULL);
 
-int spark_protocol_set_connection_property(ProtocolFacade* protocol, unsigned property_id,
-                                           unsigned data, void* datap, void* reserved);
+int spark_protocol_set_connection_property(ProtocolFacade* protocol, unsigned property_id, unsigned data, particle::protocol::keepalive_source_t source, void* reserved);
 bool spark_protocol_time_request_pending(ProtocolFacade* protocol, void* reserved=NULL);
 system_tick_t spark_protocol_time_last_synced(ProtocolFacade* protocol, time_t* tm, void* reserved=NULL);
 

--- a/communication/src/spark_protocol_functions.h
+++ b/communication/src/spark_protocol_functions.h
@@ -178,7 +178,7 @@ void spark_protocol_set_product_id(ProtocolFacade* protocol, product_id_t produc
 void spark_protocol_set_product_firmware_version(ProtocolFacade* protocol, product_firmware_version_t product_firmware_version, unsigned int param=0, void* reserved = NULL);
 void spark_protocol_get_product_details(ProtocolFacade* protocol, product_details_t* product_details, void* reserved=NULL);
 
-int spark_protocol_set_connection_property(ProtocolFacade* protocol, unsigned property_id, unsigned data, particle::protocol::keepalive_source_t source, void* reserved);
+int spark_protocol_set_connection_property(ProtocolFacade* protocol, unsigned property_id, unsigned data, particle::protocol::connection_properties_t* conn_prop, void* reserved);
 bool spark_protocol_time_request_pending(ProtocolFacade* protocol, void* reserved=NULL);
 system_tick_t spark_protocol_time_last_synced(ProtocolFacade* protocol, time_t* tm, void* reserved=NULL);
 

--- a/system/inc/system_cloud.h
+++ b/system/inc/system_cloud.h
@@ -198,7 +198,7 @@ bool spark_cloud_flag_auto_connect(void);
 
 ProtocolFacade* system_cloud_protocol_instance(void);
 
-int spark_set_connection_property(unsigned property_id, unsigned data, void* datap, void* reserved);
+int spark_set_connection_property(unsigned property_id, unsigned data, particle::protocol::keepalive_source_t source, void* reserved);
 
 int spark_set_random_seed_from_cloud_handler(void (*handler)(unsigned int), void* reserved);
 

--- a/system/inc/system_cloud.h
+++ b/system/inc/system_cloud.h
@@ -198,7 +198,7 @@ bool spark_cloud_flag_auto_connect(void);
 
 ProtocolFacade* system_cloud_protocol_instance(void);
 
-int spark_set_connection_property(unsigned property_id, unsigned data, particle::protocol::keepalive_source_t source, void* reserved);
+int spark_set_connection_property(unsigned property_id, unsigned data, particle::protocol::connection_properties_t* conn_prop, void* reserved);
 
 int spark_set_random_seed_from_cloud_handler(void (*handler)(unsigned int), void* reserved);
 

--- a/system/inc/system_dynalib_cloud.h
+++ b/system/inc/system_dynalib_cloud.h
@@ -47,7 +47,7 @@ DYNALIB_FN(10, system_cloud, spark_unsubscribe, void(void*))
 DYNALIB_FN(11, system_cloud, spark_sync_time, bool(void*))
 DYNALIB_FN(12, system_cloud, spark_sync_time_pending, bool(void*))
 DYNALIB_FN(13, system_cloud, spark_sync_time_last, system_tick_t(time_t*, void*))
-DYNALIB_FN(14, system_cloud, spark_set_connection_property, int(unsigned, unsigned, particle::protocol::keepalive_source_t, void*))
+DYNALIB_FN(14, system_cloud, spark_set_connection_property, int(unsigned, unsigned, particle::protocol::connection_properties_t*, void*))
 DYNALIB_FN(15, system_cloud, spark_set_random_seed_from_cloud_handler, int(void (*handler)(unsigned int), void*))
 
 DYNALIB_END(system_cloud)

--- a/system/inc/system_dynalib_cloud.h
+++ b/system/inc/system_dynalib_cloud.h
@@ -47,7 +47,7 @@ DYNALIB_FN(10, system_cloud, spark_unsubscribe, void(void*))
 DYNALIB_FN(11, system_cloud, spark_sync_time, bool(void*))
 DYNALIB_FN(12, system_cloud, spark_sync_time_pending, bool(void*))
 DYNALIB_FN(13, system_cloud, spark_sync_time_last, system_tick_t(time_t*, void*))
-DYNALIB_FN(14, system_cloud, spark_set_connection_property, int(unsigned, unsigned, void*, void*))
+DYNALIB_FN(14, system_cloud, spark_set_connection_property, int(unsigned, unsigned, particle::protocol::keepalive_source_t, void*))
 DYNALIB_FN(15, system_cloud, spark_set_random_seed_from_cloud_handler, int(void (*handler)(unsigned int), void*))
 
 DYNALIB_END(system_cloud)

--- a/system/src/system_cloud.cpp
+++ b/system/src/system_cloud.cpp
@@ -202,10 +202,10 @@ String spark_deviceID(void)
     return bytes2hex(id, len);
 }
 
-int spark_set_connection_property(unsigned property_id, unsigned data, void* datap, void* reserved)
+int spark_set_connection_property(unsigned property_id, unsigned data, particle::protocol::keepalive_source_t source, void* reserved)
 {
-    SYSTEM_THREAD_CONTEXT_SYNC(spark_set_connection_property(property_id, data, datap, reserved));
-    return spark_protocol_set_connection_property(sp, property_id, data, datap, reserved);
+    SYSTEM_THREAD_CONTEXT_SYNC(spark_set_connection_property(property_id, data, source, reserved));
+    return spark_protocol_set_connection_property(sp, property_id, data, source, reserved);
 }
 
 int spark_set_random_seed_from_cloud_handler(void (*handler)(unsigned int), void* reserved)

--- a/system/src/system_cloud.cpp
+++ b/system/src/system_cloud.cpp
@@ -202,10 +202,10 @@ String spark_deviceID(void)
     return bytes2hex(id, len);
 }
 
-int spark_set_connection_property(unsigned property_id, unsigned data, particle::protocol::keepalive_source_t source, void* reserved)
+int spark_set_connection_property(unsigned property_id, unsigned data, particle::protocol::connection_properties_t* conn_prop, void* reserved)
 {
-    SYSTEM_THREAD_CONTEXT_SYNC(spark_set_connection_property(property_id, data, source, reserved));
-    return spark_protocol_set_connection_property(sp, property_id, data, source, reserved);
+    SYSTEM_THREAD_CONTEXT_SYNC(spark_set_connection_property(property_id, data, conn_prop, reserved));
+    return spark_protocol_set_connection_property(sp, property_id, data, conn_prop, reserved);
 }
 
 int spark_set_random_seed_from_cloud_handler(void (*handler)(unsigned int), void* reserved)

--- a/system/src/system_task.cpp
+++ b/system/src/system_task.cpp
@@ -298,7 +298,7 @@ void establish_cloud_connection()
 
 #if PLATFORM_ID==PLATFORM_ELECTRON_PRODUCTION
         const CellularNetProvData provider_data = cellular_network_provider_data_get(NULL);
-        CLOUD_FN(spark_set_connection_property(particle::protocol::Connection::PING, (provider_data.keepalive * 1000), nullptr, nullptr), (void)0);
+        CLOUD_FN(spark_set_connection_property(particle::protocol::Connection::PING, (provider_data.keepalive * 1000), particle::protocol::KeepAliveSource::SYSTEM, nullptr), (void)0);
         spark_cloud_udp_port_set(provider_data.port);
 #endif
         INFO("Cloud: connecting");

--- a/system/src/system_task.cpp
+++ b/system/src/system_task.cpp
@@ -298,7 +298,10 @@ void establish_cloud_connection()
 
 #if PLATFORM_ID==PLATFORM_ELECTRON_PRODUCTION
         const CellularNetProvData provider_data = cellular_network_provider_data_get(NULL);
-        CLOUD_FN(spark_set_connection_property(particle::protocol::Connection::PING, (provider_data.keepalive * 1000), particle::protocol::KeepAliveSource::SYSTEM, nullptr), (void)0);
+        particle::protocol::connection_properties_t conn_prop = {0};
+        conn_prop.size = sizeof(conn_prop);
+        conn_prop.keepalive_source = particle::protocol::KeepAliveSource::SYSTEM;
+        CLOUD_FN(spark_set_connection_property(particle::protocol::Connection::PING, (provider_data.keepalive * 1000), &conn_prop, nullptr), (void)0);
         spark_cloud_udp_port_set(provider_data.port);
 #endif
         INFO("Cloud: connecting");

--- a/wiring/inc/spark_wiring_cloud.h
+++ b/wiring/inc/spark_wiring_cloud.h
@@ -336,8 +336,11 @@ public:
 #if HAL_PLATFORM_CLOUD_UDP
     static void keepAlive(unsigned sec)
     {
+        particle::protocol::connection_properties_t conn_prop = {0};
+        conn_prop.size = sizeof(conn_prop);
+        conn_prop.keepalive_source = particle::protocol::KeepAliveSource::USER;
         CLOUD_FN(spark_set_connection_property(particle::protocol::Connection::PING,
-                                               sec * 1000, particle::protocol::KeepAliveSource::USER, nullptr),
+                                               sec * 1000, &conn_prop, nullptr),
                  (void)0);
     }
 #endif

--- a/wiring/inc/spark_wiring_cloud.h
+++ b/wiring/inc/spark_wiring_cloud.h
@@ -337,7 +337,7 @@ public:
     static void keepAlive(unsigned sec)
     {
         CLOUD_FN(spark_set_connection_property(particle::protocol::Connection::PING,
-                                               sec * 1000, nullptr, nullptr),
+                                               sec * 1000, particle::protocol::KeepAliveSource::USER, nullptr),
                  (void)0);
     }
 #endif


### PR DESCRIPTION
### Problem

`Particle.keepAlive()` API was broken since v0.6.2-rc.2 firmware on Electron where the System could override a User set ping interval.  This required a workaround of updating the keepAlive after the System made a connection to the Cloud.  See issue #1482.

### Solution

Adds `keepalive_source_t` to infer when Pinger interval should be updated.  The only time the interval will not be updated is when the User has previously set it, and the System tries to override it.  All other cases are updatable.

### Steps to Test

communication unit tests added and ran by merging this PR with branch `feature/ch13052` then run `firmware/communication/tests/catch $ make all run`

Also the test app found in issue #1482 now works as expected without the workaround.

### Referencecs

fixes #1482 

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [N/A] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
