### PR TITLE
[Electron/Photon/P1] Increase Device OS API argument lengths

### DIFF
--- a/communication/src/communication_dynalib.h
+++ b/communication/src/communication_dynalib.h
@@ -73,6 +73,7 @@ DYNALIB_FN(BASE_IDX2 + 0, communication, spark_protocol_set_connection_property,
 DYNALIB_FN(BASE_IDX2 + 1, communication, spark_protocol_command, int(ProtocolFacade* protocol, ProtocolCommands::Enum cmd, uint32_t data, void* reserved))
 DYNALIB_FN(BASE_IDX2 + 2, communication, spark_protocol_time_request_pending, bool(ProtocolFacade*, void*))
 DYNALIB_FN(BASE_IDX2 + 3, communication, spark_protocol_time_last_synced, system_tick_t(ProtocolFacade*, time_t*, void*))
+DYNALIB_FN(BASE_IDX2 + 4, communication, spark_protocol_get_describe_data, int(ProtocolFacade*, spark_protocol_describe_data*, void*))
 
 DYNALIB_END(communication)
 

--- a/communication/src/messages.cpp
+++ b/communication/src/messages.cpp
@@ -307,7 +307,7 @@ size_t Messages::event(uint8_t buf[], uint16_t message_id, const char *event_nam
   *p++ = 0xb1; // one-byte Uri-Path option
   *p++ = event_type;
 
-  size_t name_data_len = strnlen(event_name, 63);
+  size_t name_data_len = strnlen(event_name, MAX_EVENT_NAME_LENGTH);
   p += event_name_uri_path(p, event_name, name_data_len);
 
   if (60 != ttl)
@@ -320,7 +320,7 @@ size_t Messages::event(uint8_t buf[], uint16_t message_id, const char *event_nam
 
   if (NULL != data)
   {
-    name_data_len = strnlen(data, 255);
+    name_data_len = strnlen(data, MAX_EVENT_DATA_LENGTH);
 
     *p++ = 0xff;
     memcpy(p, data, name_data_len);

--- a/communication/src/protocol.cpp
+++ b/communication/src/protocol.cpp
@@ -73,7 +73,7 @@ ProtocolError Protocol::handle_received_message(Message& message,
 
 	case CoAPMessageType::VARIABLE_REQUEST:
 	{
-		char variable_key[13];
+		char variable_key[MAX_VARIABLE_KEY_LENGTH+1];
 		variables.decode_variable_request(variable_key, message);
 		return variables.handle_variable_request(variable_key, message,
 				channel, token, msg_id,

--- a/communication/src/protocol.h
+++ b/communication/src/protocol.h
@@ -35,6 +35,7 @@ class Protocol
 	 * todo - move this into the message channel?
 	 */
 	system_tick_t last_message_millis;
+	system_tick_t cloud_connected_millis;
 
 	/**
 	 * The product_id represented by this device. set_product_id()
@@ -383,6 +384,8 @@ public:
 		return success;
 	}
 
+	void build_describe_message(Appender& appender, int desc_flags);
+
 	inline bool add_event_handler(const char *event_name, EventHandler handler)
 	{
 		return add_event_handler(event_name, handler, NULL,
@@ -462,6 +465,7 @@ public:
 
 	virtual int command(ProtocolCommands::Enum command, uint32_t data)=0;
 
+	virtual int get_describe_data(spark_protocol_describe_data* data, void* reserved);
 };
 
 }

--- a/communication/src/protocol_defs.h
+++ b/communication/src/protocol_defs.h
@@ -60,14 +60,23 @@ system_error_t toSystemError(ProtocolError error);
 typedef uint16_t chunk_index_t;
 
 const chunk_index_t NO_CHUNKS_MISSING = 65535;
-const chunk_index_t MAX_CHUNKS = 65535;
-const size_t MISSED_CHUNKS_TO_SEND = 50;
-const size_t MAX_FUNCTION_ARG_LENGTH = 64;
-const size_t MAX_FUNCTION_KEY_LENGTH = 12;
-const size_t MAX_VARIABLE_KEY_LENGTH = 12;
-const size_t MAX_EVENT_NAME_LENGTH = 64;
-const size_t MAX_EVENT_DATA_LENGTH = 64;
-const size_t MAX_EVENT_TTL_SECONDS = 16777215;
+const chunk_index_t MAX_CHUNKS        = 65535;
+const size_t MISSED_CHUNKS_TO_SEND    = 50;
+const size_t MAX_EVENT_TTL_SECONDS    = 16777215;
+const size_t MAX_OPTION_DELTA_LENGTH  = 12;
+#if PLATFORM_ID<2
+    const size_t MAX_FUNCTION_ARG_LENGTH = 64;
+    const size_t MAX_FUNCTION_KEY_LENGTH = 12;
+    const size_t MAX_VARIABLE_KEY_LENGTH = 12;
+    const size_t MAX_EVENT_NAME_LENGTH   = 64;
+    const size_t MAX_EVENT_DATA_LENGTH   = 255;
+#else
+    const size_t MAX_FUNCTION_ARG_LENGTH = 622;
+    const size_t MAX_FUNCTION_KEY_LENGTH = 64;
+    const size_t MAX_VARIABLE_KEY_LENGTH = 64;
+    const size_t MAX_EVENT_NAME_LENGTH   = 64;
+    const size_t MAX_EVENT_DATA_LENGTH   = 622;
+#endif
 
 // Timeout in milliseconds given to receive an acknowledgement for a published event
 const unsigned SEND_EVENT_ACK_TIMEOUT = 20000;

--- a/communication/src/spark_protocol_functions.cpp
+++ b/communication/src/spark_protocol_functions.cpp
@@ -339,7 +339,7 @@ system_tick_t spark_protocol_time_last_synced(SparkProtocol* protocol, time_t* t
     return protocol->time_last_synced(tm);
 }
 
-int spark_protocol_get_describe_data(ProtocolFacade* protocol, int flags, spark_protocol_describe_data* limits, void* reserved) {
+int spark_protocol_get_describe_data(ProtocolFacade* protocol, spark_protocol_describe_data* data, void* reserved) {
 	return -1;
 }
 

--- a/communication/src/spark_protocol_functions.cpp
+++ b/communication/src/spark_protocol_functions.cpp
@@ -206,6 +206,12 @@ system_tick_t spark_protocol_time_last_synced(ProtocolFacade* protocol, time_t* 
     return protocol->time_last_synced(tm);
 }
 
+int spark_protocol_get_describe_data(ProtocolFacade* protocol, spark_protocol_describe_data* data, void* reserved)
+{
+	return protocol->get_describe_data(data, reserved);
+}
+
+
 #else // !PARTICLE_PROTOCOL
 
 #include "spark_protocol.h"
@@ -332,5 +338,10 @@ system_tick_t spark_protocol_time_last_synced(SparkProtocol* protocol, time_t* t
     (void)reserved;
     return protocol->time_last_synced(tm);
 }
+
+int spark_protocol_get_describe_data(ProtocolFacade* protocol, int flags, spark_protocol_describe_data* limits, void* reserved) {
+	return -1;
+}
+
 
 #endif

--- a/communication/src/spark_protocol_functions.h
+++ b/communication/src/spark_protocol_functions.h
@@ -183,6 +183,15 @@ int spark_protocol_set_connection_property(ProtocolFacade* protocol, unsigned pr
 bool spark_protocol_time_request_pending(ProtocolFacade* protocol, void* reserved=NULL);
 system_tick_t spark_protocol_time_last_synced(ProtocolFacade* protocol, time_t* tm, void* reserved=NULL);
 
+typedef struct {
+	size_t size;				// size of this structure
+	uint32_t flags;				// for now 0, may be used to influence the details retrieved
+	uint16_t current_size;
+	uint16_t maximum_size;
+} spark_protocol_describe_data;
+
+int spark_protocol_get_describe_data(ProtocolFacade* protocol, spark_protocol_describe_data* limits, void* reserved);
+
 namespace ProtocolCommands {
   enum Enum {
     SLEEP,

--- a/communication/src/variables.h
+++ b/communication/src/variables.h
@@ -37,61 +37,69 @@ class Variables
 
 public:
 
-	ProtocolError decode_variable_request(char variable_key[13], Message& message)
-	{
-		uint8_t* queue = message.buf();
+    ProtocolError decode_variable_request(char variable_key[MAX_VARIABLE_KEY_LENGTH+1], Message& message)
+    {
+        uint8_t* queue = message.buf();
+        uint8_t queue_offset = 8;
 
-		// copy the variable key
-		size_t variable_key_length = queue[7] & 0x0F;
-		if (12 < variable_key_length)
-			variable_key_length = 12;
+        // copy the variable key
+        size_t variable_key_length;
+        if (queue[7] == 0x0d) {
+            variable_key_length = 0x0d + (queue[8] & 0xFF);
+            queue_offset++;
+        } else {
+            variable_key_length = queue[7] & 0x0F;
+        }
+        if (variable_key_length > MAX_VARIABLE_KEY_LENGTH) {
+            variable_key_length = MAX_VARIABLE_KEY_LENGTH;
+        }
 
-		memcpy(variable_key, queue + 8, variable_key_length);
-		memset(variable_key + variable_key_length, 0, 13 - variable_key_length);
-		return NO_ERROR;
-	}
+        memcpy(variable_key, queue + queue_offset, variable_key_length);
+        memset(variable_key + variable_key_length, 0, MAX_VARIABLE_KEY_LENGTH+1 - variable_key_length);
+        return NO_ERROR;
+    }
 
-	ProtocolError handle_variable_request(char* variable_key, Message& message, MessageChannel& channel, token_t token, message_id_t message_id,
-		SparkReturnType::Enum (*variable_type)(const char *variable_key),
-		const void *(*get_variable)(const char *variable_key))
-	{
-		uint8_t* queue = message.buf();
-		message.set_id(message_id);
-		// get variable value according to type using the descriptor
-		SparkReturnType::Enum var_type = variable_type(variable_key);
-		size_t response = 0;
+    ProtocolError handle_variable_request(char* variable_key, Message& message, MessageChannel& channel, token_t token, message_id_t message_id,
+        SparkReturnType::Enum (*variable_type)(const char *variable_key),
+        const void *(*get_variable)(const char *variable_key))
+    {
+        uint8_t* queue = message.buf();
+        message.set_id(message_id);
+        // get variable value according to type using the descriptor
+        SparkReturnType::Enum var_type = variable_type(variable_key);
+        size_t response = 0;
 
-		if(SparkReturnType::BOOLEAN == var_type)
-		{
-			const bool *bool_val = (const bool *)get_variable(variable_key);
-			response = Messages::variable_value(queue, message_id, token, *bool_val);
-		}
-		else if(SparkReturnType::INT == var_type)
-		{
-			const int *int_val = (const int *)get_variable(variable_key);
-			response = Messages::variable_value(queue, message_id, token, *int_val);
-		}
-		else if(SparkReturnType::STRING == var_type)
-		{
-			const char *str_val = (const char *)get_variable(variable_key);
+        if(SparkReturnType::BOOLEAN == var_type)
+        {
+            const bool *bool_val = (const bool *)get_variable(variable_key);
+            response = Messages::variable_value(queue, message_id, token, *bool_val);
+        }
+        else if(SparkReturnType::INT == var_type)
+        {
+            const int *int_val = (const int *)get_variable(variable_key);
+            response = Messages::variable_value(queue, message_id, token, *int_val);
+        }
+        else if(SparkReturnType::STRING == var_type)
+        {
+            const char *str_val = (const char *)get_variable(variable_key);
 
-			// 2-byte leading length, 16 potential padding bytes
-			int max_length = message.capacity();
-			int str_length = strlen(str_val);
-			if (str_length > max_length) {
-				str_length = max_length;
-			}
-			response = Messages::variable_value(queue, message_id, token, str_val, str_length);
-		}
-		else if(SparkReturnType::DOUBLE == var_type)
-		{
-			double *double_val = (double *)get_variable(variable_key);
-			response = Messages::variable_value(queue, message_id, token, *double_val);
-		}
+            // 2-byte leading length, 16 potential padding bytes
+            int max_length = message.capacity();
+            int str_length = strlen(str_val);
+            if (str_length > max_length) {
+                str_length = max_length;
+            }
+            response = Messages::variable_value(queue, message_id, token, str_val, str_length);
+        }
+        else if(SparkReturnType::DOUBLE == var_type)
+        {
+            double *double_val = (double *)get_variable(variable_key);
+            response = Messages::variable_value(queue, message_id, token, *double_val);
+        }
 
-		message.set_length(response);
-		return channel.send(message);
-	}
+        message.set_length(response);
+        return channel.send(message);
+    }
 };
 
 

--- a/system/inc/append_list.h
+++ b/system/inc/append_list.h
@@ -18,10 +18,12 @@
 
 #pragma once
 
+#include "logging.h"
+
 /**
  * A simple append-only list. The elements are never deallocated.
  */
-
+// todo - perhaps replace this with our vector implementation?
 template <typename T> class append_list
 {
     uint8_t count;
@@ -34,8 +36,10 @@ template <typename T> class append_list
             return false;
 
         T* new_store = (T*)realloc(store, sizeof(T)*capacity);
-        if (new_store)
+        if (new_store) {
             store = new_store;
+            this->capacity = capacity;
+        }
         return new_store!=NULL;
     }
 
@@ -44,19 +48,26 @@ public:
     append_list(unsigned block=5) : count(0), capacity(0), block_size(block), store(NULL) {}
 
     T* add() {
-        T* result = NULL;
-        if (add(T())) {
-            result = &store[count-1];
+    	return add(T());
+    }
+
+    T* add(const T& item) {
+        bool space = (count<capacity || expand(count+block_size));
+        T* result = nullptr;
+        if (space) {
+        	result = store + count;
+            store[count++] = item;
         }
         return result;
     }
 
-    bool add(const T& item) {
-        bool space = (count<capacity || expand(count+block_size));
-        if (space) {
-            store[count++] = item;
-        }
-        return space;
+    bool removeAt(unsigned int i) {
+    	if (i<count) {
+			T* const p = store + i;
+			memmove(p, p + 1, count - i - 1);
+			count--;
+    	}
+        return true;
     }
 
     T& operator[](unsigned index) { return store[index]; }

--- a/system/inc/system_cloud.h
+++ b/system/inc/system_cloud.h
@@ -221,15 +221,22 @@ extern const unsigned char backup_tcp_public_server_address[18];
 #define TIMING_FLASH_UPDATE_TIMEOUT   30000   //30sec
 #endif
 
-#define USER_VAR_MAX_COUNT            10
-#define USER_VAR_KEY_LENGTH           12
+#define USER_VAR_MAX_COUNT            (10)  // FIXME: NOT USED
+#define USER_FUNC_MAX_COUNT           (4)   // FIXME: NOT USED
 
-#define USER_FUNC_MAX_COUNT           4
-#define USER_FUNC_KEY_LENGTH          12
-#define USER_FUNC_ARG_LENGTH          64
-
-#define USER_EVENT_NAME_LENGTH        64
-#define USER_EVENT_DATA_LENGTH        64
+#if PLATFORM_ID<2
+    #define USER_FUNC_ARG_LENGTH      (64)  // FIXME: NOT USED
+    #define USER_VAR_KEY_LENGTH       (12)
+    #define USER_FUNC_KEY_LENGTH      (12)
+    #define USER_EVENT_NAME_LENGTH    (64)  // FIXME: NOT USED
+    #define USER_EVENT_DATA_LENGTH    (64)  // FIXME: NOT USED
+#else
+    #define USER_FUNC_ARG_LENGTH      (622) // FIXME: NOT USED
+    #define USER_VAR_KEY_LENGTH       (64)
+    #define USER_FUNC_KEY_LENGTH      (64)
+    #define USER_EVENT_NAME_LENGTH    (64)  // FIXME: NOT USED
+    #define USER_EVENT_DATA_LENGTH    (622) // FIXME: NOT USED
+#endif
 
 #ifdef __cplusplus
 }

--- a/system/inc/system_cloud.h
+++ b/system/inc/system_cloud.h
@@ -152,6 +152,14 @@ typedef struct spark_variable_t
     const void* (*update)(const char* nane, Spark_Data_TypeDef type, const void* var, void* reserved);
 } spark_variable_t;
 
+/**
+ * @brief Register a new variable.
+ * @param varKey	The name of the variable. The length should be between 1 and USER_VAR_KEY_LENGTH bytes.
+ * @param userVar	A pointer to the memory for the variable.
+ * @param userVarType	The type of the variable.
+ * @param extra		Additional registration details.
+ * 		update	A function used to case a variable value to be computed. If defined, this is called when the variable's value is retrieved.
+ */
 bool spark_variable(const char *varKey, const void *userVar, Spark_Data_TypeDef userVarType, spark_variable_t* extra);
 
 /**

--- a/system/src/system_cloud.cpp
+++ b/system/src/system_cloud.cpp
@@ -133,16 +133,7 @@ bool spark_variable(const char *varKey, const void *userVar, Spark_Data_TypeDef 
     User_Var_Lookup_Table_t* item = NULL;
     if (NULL != userVar && NULL != varKey && strlen(varKey)<=USER_VAR_KEY_LENGTH)
     {
-        if ((item=find_var_by_key_or_add(varKey))!=NULL)
-        {
-            item->userVar = userVar;
-            item->userVarType = userVarType;
-            if (extra) {
-                item->update = extra->update;
-            }
-            memset(item->userVarKey, 0, USER_VAR_KEY_LENGTH);
-            memcpy(item->userVarKey, varKey, USER_VAR_KEY_LENGTH);
-        }
+    	item=find_var_by_key_or_add(varKey, userVar, userVarType, extra);
     }
     return item!=NULL;
 }

--- a/system/src/system_cloud_internal.h
+++ b/system/src/system_cloud_internal.h
@@ -75,8 +75,8 @@ struct User_Func_Lookup_Table_t
 };
 
 
-User_Var_Lookup_Table_t* find_var_by_key_or_add(const char* varKey);
-User_Func_Lookup_Table_t* find_func_by_key_or_add(const char* funcKey);
+User_Var_Lookup_Table_t* find_var_by_key_or_add(const char* varKey, const void* userVarData, Spark_Data_TypeDef userVarType, spark_variable_t* extra);
+User_Func_Lookup_Table_t* find_func_by_key_or_add(const char* funcKey, const cloud_function_descriptor* desc);
 
 extern ProtocolFacade* sp;
 


### PR DESCRIPTION
### Problem

Device OS API arguments have limitations that can be increased.

### Solution

| API Field | Old | New | Comment |
|--:|--:|--:|:--|
| Variable Key | 12 | 64 | |
| Variable Data | 622 | 622 | |
| Function Key | 12 | 64 | |
| Function Argument | 63 | 622 | |
| Publish/Subscribe Event Name | 64 | 64 | |
| Publish/Subscribe Event Data | 255 | 622 | Cloud API currently still limits to 255, but Device OS can publish 622.  Will change Cloud API to accept 622. |
| Number of registered Functions or Variables | limited by memory available | limited by memory available | |

An additional feature has been added that will return `false` when attempting to register a `Particle.variable()` or `Particle.function()` that exceeds the memory limits of the describe message (about 800 bytes for the Photon/P1/Electron).  This message is a JSON object that describes or lists the "keys" needed.  When an error occurs, that Variable or Function will be removed from the list available.

### Steps to Test

Included test app.

### Example App

```c
#include "Particle.h"

#define PUB_70 "123456789012345678901234567890123456789012345678901234567890ABCDEFGHIJ"
#define SUB_70 "123456789012345678901234567890123456789012345678901234567890ABCDEFGHIJ"
#define VAR_70 "123456789012345678901234567890123456789012345678901234567890ABCDEFGHIJ"
#define VAR_64 "123456789012345678901234567890123456789012345678901234567890ABCD"
#define VAR_63 "123456789012345678901234567890123456789012345678901234567890ABC"
#define VAR_62 "123456789012345678901234567890123456789012345678901234567890AB"
#define VAR_61 "123456789012345678901234567890123456789012345678901234567890A"
#define VAR_60 "123456789012345678901234567890123456789012345678901234567890"
#define VAR_13 "1234567890123"
#define VAR_12 "123456789012"
#define VAR_OVF "12345678901234567890123456789012345678901234567890"

#define FUN_70 "123456789012345678901234567890123456789012345678901234567890ABCDEFGHIJ"
#define FUN_64 "123456789012345678901234567890123456789012345678901234567890ABCD"
#define FUN_63 "123456789012345678901234567890123456789012345678901234567890ABC"
#define FUN_62 "123456789012345678901234567890123456789012345678901234567890AB"
#define FUN_61 "123456789012345678901234567890123456789012345678901234567890A"
#define FUN_60 "123456789012345678901234567890123456789012345678901234567890"
#define FUN_13 "1234567890123"
#define FUN_12 "123456789012"

#define CHAR_700 "12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890ABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJ"
#define CHAR_622 "12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890AB"

String my_variable_ovf = CHAR_622;
String my_variable_12 = CHAR_622;
String my_variable_13 = CHAR_622;
String my_variable_60 = CHAR_622;
String my_variable_61 = CHAR_622;
String my_variable_62 = CHAR_622;
String my_variable_63 = CHAR_622;
String my_variable_64 = CHAR_622;
String my_variable_70 = CHAR_700;

Serial1LogHandler logHandler(115200, LOG_LEVEL_ALL);

void handler(const char *event, const char *data)
{
    String my_event(event);
    String my_data(data);
    Serial.printlnf("Event Length: %d, Data Length: %d", my_event.length(), my_data.length() );
    Serial.printlnf("Event Name: %s, Event Data: %s", my_event.c_str(), my_data.c_str() );
}

void printInfo(String& string) {
    Serial.printlnf("Function Argument Length: %d", string.length() );
    Serial.printlnf("Function Argument: %s", string.c_str() );
}
int my_function_70(String arg) {
    printInfo(arg);
    return 0;
}
int my_function_64(String arg) {
    printInfo(arg);
    return 0;
}
int my_function_63(String arg) {
    printInfo(arg);
    return 0;
}
int my_function_62(String arg) {
    printInfo(arg);
    return 0;
}
int my_function_61(String arg) {
    printInfo(arg);
    return 0;
}
int my_function_60(String arg) {
    printInfo(arg);
    return 0;
}
int my_function_50(String arg) {
    printInfo(arg);
    return 0;
}
int my_function_13(String arg) {
    printInfo(arg);
    return 0;
}
int my_function_12(String arg) {
    printInfo(arg);
    return 0;
}
int my_function_ovf(String arg) {
    printInfo(arg);
    return 0;
}

void setup() {
    Serial.begin();

    // Particle.function(FUN_70, my_function_70); // error on compile (error shows 64 limit)
    Particle.function(FUN_12, my_function_12); // can receive 622 bytes as an argument
    Particle.function(FUN_13, my_function_13); // can receive 622 bytes as an argument
    Particle.function(FUN_60, my_function_60); // can receive 622 bytes as an argument
    Particle.function(FUN_61, my_function_61); // can receive 622 bytes as an argument
    Particle.function(FUN_62, my_function_62); // can receive 622 bytes as an argument
    Particle.function(FUN_63, my_function_63); // can receive 622 bytes as an argument
    Particle.function(FUN_64, my_function_64); // can receive 622 bytes as an argument

    // Particle.variable(VAR_70, &my_variable_70, STRING); // error on compile (error shows 64 limit)
    Particle.variable(VAR_12, &my_variable_12, STRING); // returns CHAR_622
    Particle.variable(VAR_13, &my_variable_13, STRING); // returns CHAR_622
    Particle.variable(VAR_60, &my_variable_60, STRING); // returns CHAR_622
    Particle.variable(VAR_61, &my_variable_61, STRING); // returns CHAR_622
    Particle.variable(VAR_62, &my_variable_62, STRING); // returns CHAR_622
    Particle.variable(VAR_63, &my_variable_63, STRING); // returns CHAR_622
    Particle.variable(VAR_64, &my_variable_64, STRING); // returns CHAR_622
    // Particle.variable(VAR_OVF, &my_variable_ovf, STRING); // add to increase describe message over the limit

    Particle.subscribe(SUB_70, handler, MY_DEVICES); // event 64 and data 255 (limited by Cloud API)
    waitUntil(Particle.connected);

    Particle.publish(PUB_70, CHAR_700, PRIVATE, WITH_ACK); // event 64 and data 622
}

void loop() {

}
```

### References

Closes #1467 

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [TODO] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
