### PR TITLE
[Electron] Fixes monolithic build

### DIFF
--- a/hal/src/electron/modem/dns_client.cpp
+++ b/hal/src/electron/modem/dns_client.cpp
@@ -56,6 +56,9 @@
 #include "dns_client.h"
 
 #include "mdm_hal.h"
+#include <stdio.h>
+#include "timer_hal.h"
+#include "delay_hal.h"
 #include "system_error.h"
 
 #include <memory>


### PR DESCRIPTION
### Problem

`firmware/main$ make clean all -s PLATFORM=electron MODULAR=n` was failing

### Solution

Adds a few missing headers

### Steps to Test

Should build without errors `firmware/main$ make clean all -s PLATFORM=electron MODULAR=n`

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] Added documentation (N/A)
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
