### PR TITLE
[Electron] fixes sticker-rig issue with POWER_ON command

### DIFF
--- a/wiring/src/spark_wiring_wifitester.cpp
+++ b/wiring/src/spark_wiring_wifitester.cpp
@@ -309,14 +309,14 @@ void WiFiTester::checkWifiSerial(char c) {
         } else if ((start = strstr(command, cmd_DFU))) {
             serialPrintln("DFU mode! DFU mode! DFU mode! DFU mode! DFU mode! DFU mode!");
             serialPrintln("DFU mode! DFU mode! DFU mode! DFU mode! DFU mode! DFU mode!");
-            delay(200);
+            HAL_Delay_Milliseconds(200);
 
             System.dfu();
         } else if ((start = strstr(command, cmd_RESET))) {
             //to trigger a factory reset:
             serialPrintln("factory reset! factory reset! factory reset! factory reset!");
             serialPrintln("factory reset! factory reset! factory reset! factory reset!");
-            delay(200);
+            HAL_Delay_Milliseconds(200);
 
             System.factoryReset();
         } else if ((start = strstr(command, cmd_UNLOCK))) {
@@ -343,14 +343,14 @@ void WiFiTester::checkWifiSerial(char c) {
             serialPrintln("Rebooting... Rebooting... Rebooting...");
             serialPrintln("Rebooting... Rebooting... Rebooting...");
 
-            delay(200);
+            HAL_Delay_Milliseconds(200);
             System.reset();
         } else if ((start = strstr(command, cmd_POWER_ON))) {
             serialPrintln("Power on... Power on... Power on...");
             serialPrintln("Power on... Power on... Power on...");
 
 #if Wiring_Cellular
-            delay(200);
+            HAL_Delay_Milliseconds(200);
             cellular_result_t result = cellular_on(NULL);
             if (result == 0) {
                 power_state = true;
@@ -364,7 +364,7 @@ void WiFiTester::checkWifiSerial(char c) {
             } else {
                 serialPrintln("POWER FAILED TO TURN ON!!!");
             }
-            delay(200);
+            HAL_Delay_Milliseconds(200);
         } else if ((start = strstr(command, cmd_INFO))) {
             printInfo();
         }


### PR DESCRIPTION
### Problem

`POWER_ON:;` was operating intermittently in the Sticker Rig during MFG'ing for LTE E-Series modules.

### Solution

`delay(200)` used in the test routine was changed to `HAL_Delay_Milliseconds(200)` to avoid the situation where the `spark_process()` is run after an accumulation of 1s.  This was causing the device to try to re-connect to the cloud while it was in listening mode, and AT commands were getting interrupted.

### Steps to Test

Run `firmware/user/tests/accept/sticker-rig` test several times to verify it completes successfully.

E.g. with Python 2.7.14 installed, running:

`python test.py /dev/cu.usbserial-A702OGCQ /dev/cu.usbmodem141441`

Test will complete without failure each time:

`Tests PASSED!!`

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] Added documentation (N/A)
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
