### PR TITLE
Bug fixes for SARA_R410 LTE E Series [ch16140]

### DIFF
--- a/communication/src/chunked_transfer.cpp
+++ b/communication/src/chunked_transfer.cpp
@@ -33,6 +33,16 @@ ProtocolError ChunkedTransfer::handle_update_begin(
     if (actual_len >= 20 && queue[7] == 0xFF)
     {
         flags = decode_uint8(queue + 8);
+
+        if (fast_ota_override) {
+            if (fast_ota_value) {
+                flags |= (1<<0); // enabled
+            } else {
+                flags &= ~(1<<0); // disabled
+            }
+            DEBUG("Fast OTA: %s", fast_ota_value?"enabled":"disabled");
+        }
+
         file.chunk_size = decode_uint16(queue + 9);
         file.file_length = decode_uint32(queue + 11);
         file.store = FileTransfer::Store::Enum(decode_uint8(queue + 15));

--- a/communication/src/chunked_transfer.h
+++ b/communication/src/chunked_transfer.h
@@ -82,6 +82,9 @@ private:
 
 	Callbacks* callbacks;
 
+	bool fast_ota_override;
+	bool fast_ota_value;
+
 protected:
 
 	unsigned chunk_bitmap_size()
@@ -110,7 +113,7 @@ protected:
 public:
 
 	ChunkedTransfer() :
-			updating(false), callbacks(nullptr)
+			updating(false), callbacks(nullptr), fast_ota_override(false), fast_ota_value(true)
 	{
 	}
 
@@ -135,6 +138,12 @@ public:
 	ProtocolError send_missing_chunks(MessageChannel& channel, size_t count);
 
 	ProtocolError idle(MessageChannel& channel);
+
+	void set_fast_ota(unsigned data)
+	{
+		fast_ota_value = (data > 0) ? true : false;
+		fast_ota_override = true;
+	}
 
 	bool is_updating()
 	{

--- a/communication/src/protocol.h
+++ b/communication/src/protocol.h
@@ -298,6 +298,11 @@ public:
 		pinger.set_interval(interval, source);
 	}
 
+	void set_fast_ota(unsigned data)
+	{
+		chunkedTransfer.set_fast_ota(data);
+	}
+
 	void set_handlers(CommunicationsHandlers& handlers)
 	{
 		copy_and_init(&this->handlers, sizeof(this->handlers), &handlers, handlers.size);

--- a/communication/src/protocol_defs.h
+++ b/communication/src/protocol_defs.h
@@ -109,7 +109,8 @@ namespace Connection
 {
 enum Enum
 {
-    PING = 0
+    PING = 0,
+    FAST_OTA = 1
 };
 }
 

--- a/communication/src/spark_protocol_functions.cpp
+++ b/communication/src/spark_protocol_functions.cpp
@@ -186,6 +186,9 @@ int spark_protocol_set_connection_property(ProtocolFacade* protocol, unsigned pr
     if (property_id == particle::protocol::Connection::PING)
     {
         protocol->set_keepalive(data, conn_prop->keepalive_source);
+    } else if (property_id == particle::protocol::Connection::FAST_OTA)
+    {
+        protocol->set_fast_ota(data);
     }
     return 0;
 }

--- a/hal/inc/cellular_hal_constants.h
+++ b/hal/inc/cellular_hal_constants.h
@@ -40,6 +40,7 @@ typedef void (*_CELLULAR_SMS_CB_MDM)(void* data, int index);
 #define DEFINE_NET_PROVIDER_DATA \
     DEFINE_NET_PROVIDER( CELLULAR_NETPROV_TELEFONICA, "spark.telefonica.com", (23*60), (5684) ),  \
     DEFINE_NET_PROVIDER( CELLULAR_NETPROV_TWILIO, "wireless.twilio.com", (23*60), (4500) ),  \
+    DEFINE_NET_PROVIDER( CELLULAR_NETPROV_KORE, "", (30), (5684) ),  \
     DEFINE_NET_PROVIDER( CELLULAR_NETPROV_MAX, "", (0), (0) )
 
 #define DEFINE_NET_PROVIDER( idx, apn, keepalive, port )  idx

--- a/hal/src/electron/cellular_hal.cpp
+++ b/hal/src/electron/cellular_hal.cpp
@@ -26,7 +26,16 @@ const char* defaultOrUserApn(const CellularCredentials& cred)
         // Determine APN based on IMSI
         auto ret = cellular_imsi_to_network_provider(nullptr);
         if (ret != 0) {
+            // Should never get here since we always return 0 from above
             return cred.apn;
+        }
+        // If we are potentially still defaulting to Telefonica, check for R410 modem type
+        if (cellularNetProv == CELLULAR_NETPROV_TELEFONICA) {
+            // Determine APN based on Modem Type
+            const DevStatus* const status = electronMDM.getDevStatus();
+            if (status->dev == DEV_SARA_R410) {
+                cellularNetProv = CELLULAR_NETPROV_KORE;
+            }
         }
         return CELLULAR_NET_PROVIDER_DATA[cellularNetProv].apn;
     }
@@ -145,11 +154,8 @@ cellular_result_t cellular_connect(void* reserved)
 {
     const CellularCredentials& cred = cellularCredentials;
     const char* apn = cred.apn;
-    const DevStatus* const status = electronMDM.getDevStatus();
-    if (status->dev != DEV_SARA_R410) {
-        // TODO: Look for an APN based on IMSI for LTE providers as well
-        apn = defaultOrUserApn(cred);
-    }
+    // TODO: Look for an APN based on IMSI for LTE providers as well
+    apn = defaultOrUserApn(cred);
     CHECK_SUCCESS(electronMDM.connect(apn, cred.username, cred.password));
     return 0;
 }

--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -318,7 +318,9 @@ int MDMParser::waitFinalResp(_CALLBACKPTR cb /* = NULL*/,
                     DEBUG_D("New SMS at index %d\r\n", a);
                     if (sms_cb) SMSreceived(a);
                 }
-                else if ((sscanf(cmd, "CIEV: 9,%d", &a) == 1)) {
+                // TODO: This should include other LTE devices,
+                // perhaps adding _net.act < 7
+                else if ((_dev.dev != DEV_SARA_R410) && (sscanf(cmd, "CIEV: 9,%d", &a) == 1)) {
                     DEBUG_D("CIEV matched: 9,%d\r\n", a);
                     // Wait until the system is attached before attempting to act on GPRS detach
                     if (_attached) {

--- a/system/src/system_task.cpp
+++ b/system/src/system_task.cpp
@@ -303,6 +303,15 @@ void establish_cloud_connection()
         conn_prop.keepalive_source = particle::protocol::KeepAliveSource::SYSTEM;
         CLOUD_FN(spark_set_connection_property(particle::protocol::Connection::PING, (provider_data.keepalive * 1000), &conn_prop, nullptr), (void)0);
         spark_cloud_udp_port_set(provider_data.port);
+
+        CellularDevice device;
+        memset(&device, 0, sizeof(device));
+        device.size = sizeof(device);
+        cellular_device_info(&device, NULL);
+        if (device.dev == 8/*DEV_SARA_R410*/) {
+            DEBUG("Device is SARA_R410, disabling Fast OTA!");
+            CLOUD_FN(spark_set_connection_property(particle::protocol::Connection::FAST_OTA, 0/*disabled*/, nullptr, nullptr), (void)0);
+        }
 #endif
         INFO("Cloud: connecting");
         const auto diag = CloudDiagnostics::instance();


### PR DESCRIPTION
### Problem

- GPRS URCs (CIEV: 9,x) were causing SARA_R410 to disconnect
- Fast OTA is not working correctly for SARA_R410
- Kore SIMs on SARA_R410 experience a UDP NAT timeout after 60s

### Solution

- GPRS URCs disabled on SARA_R410
- disables Fast OTA for SARA_R410
- enables 30 second ping for Kore SIMs on SARA_R410

### Steps to Test

- Test with Kore SIM on SARA_R410 E Series, should exhibit 30 second ping, port 5684 and use Slow OTA updates.
- Test with any SIM on SARA_R410 E Series with 3rd Party credentials API with no Particle.keepAlive() API, should exhibit 23 minute ping, port 5684 and use Slow OTA updates (should connect using custom APN).
- Test with Twilio SIM on U260 Electron, should exhibit 23 minute ping, port 4500 and use Fast OTA updates.
- Test with Telefonica SIM on U260 Electron, should exhibit 23 minute ping, port 5684 and use Fast OTA updates.

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] Added documentation (N/A)
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
