### PR TITLE
[LTE/Electron] Fast OTA Fixes [ch16346]

### DIFF
--- a/communication/src/chunked_transfer.cpp
+++ b/communication/src/chunked_transfer.cpp
@@ -111,6 +111,7 @@ ProtocolError ChunkedTransfer::handle_update_begin(
 ProtocolError ChunkedTransfer::handle_chunk(token_t token, Message& message,
         MessageChannel& channel)
 {
+    first_chunk_received = true;
     last_chunk_millis = callbacks->millis();
 
     Message response;
@@ -349,9 +350,10 @@ ProtocolError ChunkedTransfer::send_missing_chunks(MessageChannel& channel,
 ProtocolError ChunkedTransfer::idle(MessageChannel& channel)
 {
     system_tick_t millis_since_last_chunk = callbacks->millis() - last_chunk_millis;
-    if (3000 < millis_since_last_chunk)
+    if (first_chunk_received && 3000 < millis_since_last_chunk)
     {
-        if (updating == 2)
+        // Check for timeout on initial update phase "updating = 1", and successive phases "updating =2".
+        if (updating > 0)
         {    // send missing chunks
             WARN("timeout - resending missing chunks");
             Message message;

--- a/communication/src/chunked_transfer.cpp
+++ b/communication/src/chunked_transfer.cpp
@@ -279,8 +279,8 @@ ProtocolError ChunkedTransfer::handle_update_done(token_t token, Message& messag
     {
         updating = 2;       // flag that we are sending missing chunks.
         DEBUG("update done - missing chunks starting at %d", index);
-        chunk_index_t increase = std::max(chunk_index_t(chunk_count*0.2),chunk_index_t(2u));	// ensure always some growth
-        chunk_index_t resend_chunk_count = std::min(std::max(2u,unsigned(chunk_count+increase)), MISSED_CHUNKS_TO_SEND);
+        chunk_index_t increase = std::max(unsigned(chunk_count*0.2), MINIMUM_CHUNK_INCREASE);	// ensure always some growth
+        chunk_index_t resend_chunk_count = std::min(unsigned(chunk_count+increase), MISSED_CHUNKS_TO_SEND);
         chunk_count = 0;
 
         error = send_missing_chunks(channel, resend_chunk_count);

--- a/communication/src/chunked_transfer.cpp
+++ b/communication/src/chunked_transfer.cpp
@@ -302,7 +302,8 @@ ProtocolError ChunkedTransfer::handle_update_done(token_t token, Message& messag
     {
         updating = 2;       // flag that we are sending missing chunks.
         DEBUG("update done - missing chunks starting at %d", index);
-        chunk_index_t resend_chunk_count = std::min(std::max(2u,unsigned(chunk_count*1.2)), MISSED_CHUNKS_TO_SEND);
+        chunk_index_t increase = std::max(chunk_index_t(chunk_count*0.2),chunk_index_t(2u));	// ensure always some growth
+        chunk_index_t resend_chunk_count = std::min(std::max(2u,unsigned(chunk_count+increase)), MISSED_CHUNKS_TO_SEND);
         chunk_count = 0;
 
         error = send_missing_chunks(channel, resend_chunk_count);

--- a/communication/src/chunked_transfer.cpp
+++ b/communication/src/chunked_transfer.cpp
@@ -27,7 +27,7 @@ ProtocolError ChunkedTransfer::handle_update_begin(
         token_t token, Message& message, MessageChannel& channel)
 {
     uint8_t flags = 0;
-	chunk_count = 0;
+    chunk_count = 0;
     int actual_len = message.length();
     uint8_t* queue = message.buf();
     message_id_t msg_id = CoAP::message_id(queue);
@@ -112,7 +112,6 @@ ProtocolError ChunkedTransfer::handle_update_begin(
 ProtocolError ChunkedTransfer::handle_chunk(token_t token, Message& message,
         MessageChannel& channel)
 {
-    first_chunk_received = true;
     last_chunk_millis = callbacks->millis();
     chunk_count++;
 
@@ -339,6 +338,8 @@ ProtocolError ChunkedTransfer::send_missing_chunks(MessageChannel& channel,
 
 ProtocolError ChunkedTransfer::idle(MessageChannel& channel)
 {
+    /* Timeout to resend missing chunks removed.
+     * Leaving idle() here in case we need to add something in the future. */
     return NO_ERROR;
 }
 

--- a/communication/src/chunked_transfer.cpp
+++ b/communication/src/chunked_transfer.cpp
@@ -124,7 +124,9 @@ ProtocolError ChunkedTransfer::handle_chunk(token_t token, Message& message,
     if (!is_updating())
     {
         WARN("got chunk when not updating");
-        return INVALID_STATE;
+        // TODO: return INVALID_STATE after we add a way to have
+        // the server ACK our UpdateDone ACK before we reset_updating().
+        return NO_ERROR;
     }
 
     bool fast_ota = false;
@@ -187,17 +189,6 @@ ProtocolError ChunkedTransfer::handle_chunk(token_t token, Message& message,
                 response_size = Messages::chunk_received(response.buf(), 0, token, ChunkReceivedCode::OK, channel.is_unreliable());
             }
             flag_chunk_received(chunk_index);
-            if (updating == 2)
-            {            // clearing up missed chunks at the end of fast OTA
-                chunk_index_t next_missed = next_chunk_missing(0);
-                if (next_missed == NO_CHUNKS_MISSING)
-                {
-                    INFO("received all chunks");
-                    reset_updating();
-                    response_size = notify_update_done(message, response, channel, 0, 0);
-                    callbacks->finish_firmware_update(file, UpdateFlag::SUCCESS, NULL);
-                }
-            }
             chunk_index++;
         }
         else
@@ -272,8 +263,11 @@ ProtocolError ChunkedTransfer::handle_update_done(token_t token, Message& messag
     if (error)
         return error;
 
-    if (!is_updating())
-        return INVALID_STATE;
+    if (!is_updating()) {
+        // TODO: return INVALID_STATE after we add a way to have
+        // the server ACK our UpdateDone ACK before we reset_updating().
+        return NO_ERROR;
+    }
 
     if (!missing)
     {

--- a/communication/src/chunked_transfer.cpp
+++ b/communication/src/chunked_transfer.cpp
@@ -27,6 +27,7 @@ ProtocolError ChunkedTransfer::handle_update_begin(
         token_t token, Message& message, MessageChannel& channel)
 {
     uint8_t flags = 0;
+	chunk_count = 0;
     int actual_len = message.length();
     uint8_t* queue = message.buf();
     message_id_t msg_id = CoAP::message_id(queue);
@@ -113,6 +114,7 @@ ProtocolError ChunkedTransfer::handle_chunk(token_t token, Message& message,
 {
     first_chunk_received = true;
     last_chunk_millis = callbacks->millis();
+    chunk_count++;
 
     Message response;
     ProtocolError error;
@@ -300,7 +302,10 @@ ProtocolError ChunkedTransfer::handle_update_done(token_t token, Message& messag
     {
         updating = 2;       // flag that we are sending missing chunks.
         DEBUG("update done - missing chunks starting at %d", index);
-        error = send_missing_chunks(channel, MISSED_CHUNKS_TO_SEND);
+        chunk_index_t resend_chunk_count = std::min(std::max(2u,unsigned(chunk_count*1.2)), MISSED_CHUNKS_TO_SEND);
+        chunk_count = 0;
+
+        error = send_missing_chunks(channel, resend_chunk_count);
         last_chunk_millis = callbacks->millis();
     }
     return error;

--- a/communication/src/chunked_transfer.h
+++ b/communication/src/chunked_transfer.h
@@ -84,6 +84,7 @@ private:
 
 	bool fast_ota_override;
 	bool fast_ota_value;
+	bool first_chunk_received;
 
 protected:
 
@@ -113,7 +114,8 @@ protected:
 public:
 
 	ChunkedTransfer() :
-			updating(false), callbacks(nullptr), fast_ota_override(false), fast_ota_value(true)
+			updating(false), callbacks(nullptr), fast_ota_override(false),
+			fast_ota_value(true), first_chunk_received(false)
 	{
 	}
 
@@ -127,6 +129,7 @@ public:
 		reset_updating();
 		bitmap = nullptr;
 		last_chunk_millis = 0;
+		first_chunk_received = false;
 	}
 
 	ProtocolError handle_update_begin(token_t token, Message& message, MessageChannel& channel);
@@ -154,6 +157,7 @@ public:
 	{
 		updating = false;
 		last_chunk_millis = 0;    // this is used for the time latency also
+		first_chunk_received = false;
 	}
 
 	void cancel();

--- a/communication/src/chunked_transfer.h
+++ b/communication/src/chunked_transfer.h
@@ -89,7 +89,6 @@ private:
 
 	bool fast_ota_override;
 	bool fast_ota_value;
-	bool first_chunk_received;
 
 protected:
 
@@ -119,8 +118,7 @@ protected:
 public:
 
 	ChunkedTransfer() :
-			updating(false), callbacks(nullptr), fast_ota_override(false),
-			fast_ota_value(true), first_chunk_received(false)
+			updating(false), callbacks(nullptr), fast_ota_override(false), fast_ota_value(true)
 	{
 	}
 
@@ -134,7 +132,6 @@ public:
 		reset_updating();
 		bitmap = nullptr;
 		last_chunk_millis = 0;
-		first_chunk_received = false;
 	}
 
 	ProtocolError handle_update_begin(token_t token, Message& message, MessageChannel& channel);
@@ -162,7 +159,6 @@ public:
 	{
 		updating = false;
 		last_chunk_millis = 0;    // this is used for the time latency also
-		first_chunk_received = false;
 	}
 
 	void cancel();

--- a/communication/src/chunked_transfer.h
+++ b/communication/src/chunked_transfer.h
@@ -75,6 +75,11 @@ private:
 	 * Marks the indices of missed chunks not yet requested.
 	 */
 	chunk_index_t missed_chunk_index;
+	/**
+	 * Number of chunks received in the current flight of chunks (between UpdateBegin|UpdateDone and UpdateDone)
+	 */
+	chunk_index_t chunk_count;
+
 	unsigned short chunk_index;
 	unsigned short chunk_size;
 

--- a/communication/src/protocol_defs.h
+++ b/communication/src/protocol_defs.h
@@ -61,7 +61,7 @@ typedef uint16_t chunk_index_t;
 
 const chunk_index_t NO_CHUNKS_MISSING = 65535;
 const chunk_index_t MAX_CHUNKS        = 65535;
-const size_t MISSED_CHUNKS_TO_SEND    = 50;
+const size_t MISSED_CHUNKS_TO_SEND    = 40;
 const size_t MAX_EVENT_TTL_SECONDS    = 16777215;
 const size_t MAX_OPTION_DELTA_LENGTH  = 12;
 #if PLATFORM_ID<2

--- a/communication/src/protocol_defs.h
+++ b/communication/src/protocol_defs.h
@@ -62,6 +62,7 @@ typedef uint16_t chunk_index_t;
 const chunk_index_t NO_CHUNKS_MISSING = 65535;
 const chunk_index_t MAX_CHUNKS        = 65535;
 const size_t MISSED_CHUNKS_TO_SEND    = 40u;
+const size_t MINIMUM_CHUNK_INCREASE   = 2u;
 const size_t MAX_EVENT_TTL_SECONDS    = 16777215;
 const size_t MAX_OPTION_DELTA_LENGTH  = 12;
 #if PLATFORM_ID<2

--- a/communication/src/protocol_defs.h
+++ b/communication/src/protocol_defs.h
@@ -61,7 +61,7 @@ typedef uint16_t chunk_index_t;
 
 const chunk_index_t NO_CHUNKS_MISSING = 65535;
 const chunk_index_t MAX_CHUNKS        = 65535;
-const size_t MISSED_CHUNKS_TO_SEND    = 40;
+const size_t MISSED_CHUNKS_TO_SEND    = 40u;
 const size_t MAX_EVENT_TTL_SECONDS    = 16777215;
 const size_t MAX_OPTION_DELTA_LENGTH  = 12;
 #if PLATFORM_ID<2

--- a/system/src/system_task.cpp
+++ b/system/src/system_task.cpp
@@ -310,7 +310,7 @@ void establish_cloud_connection()
         cellular_device_info(&device, NULL);
         if (device.dev == 8/*DEV_SARA_R410*/) {
             DEBUG("Device is SARA_R410, disabling Fast OTA!");
-            CLOUD_FN(spark_set_connection_property(particle::protocol::Connection::FAST_OTA, 0/*disabled*/, nullptr, nullptr), (void)0);
+            CLOUD_FN(spark_set_connection_property(particle::protocol::Connection::FAST_OTA, 1/*disabled*/, nullptr, nullptr), (void)0);
         }
 #endif
         INFO("Cloud: connecting");

--- a/system/src/system_task.cpp
+++ b/system/src/system_task.cpp
@@ -303,15 +303,6 @@ void establish_cloud_connection()
         conn_prop.keepalive_source = particle::protocol::KeepAliveSource::SYSTEM;
         CLOUD_FN(spark_set_connection_property(particle::protocol::Connection::PING, (provider_data.keepalive * 1000), &conn_prop, nullptr), (void)0);
         spark_cloud_udp_port_set(provider_data.port);
-
-        CellularDevice device;
-        memset(&device, 0, sizeof(device));
-        device.size = sizeof(device);
-        cellular_device_info(&device, NULL);
-        if (device.dev == 8/*DEV_SARA_R410*/) {
-            DEBUG("Device is SARA_R410, disabling Fast OTA!");
-            CLOUD_FN(spark_set_connection_property(particle::protocol::Connection::FAST_OTA, 1/*disabled*/, nullptr, nullptr), (void)0);
-        }
 #endif
         INFO("Cloud: connecting");
         const auto diag = CloudDiagnostics::instance();

--- a/system/src/system_update.cpp
+++ b/system/src/system_update.cpp
@@ -335,6 +335,7 @@ int Spark_Finish_Firmware_Update(FileTransfer::Descriptor& file, uint32_t flags,
             // always restart for now
             if (true || result==HAL_UPDATE_APPLIED_PENDING_RESTART)
             {
+                spark_protocol_command(sp, ProtocolCommands::DISCONNECT);
                 system_pending_shutdown();
             }
         }


### PR DESCRIPTION
### Problem

- Fast OTA on the E Series LTE v0.8.0-rc.8 is disabled pending a Cat-M1 rate limit investigation.  Chunks would hang at index 48 out of 49, and usually be missing most of the 0-48.
- Devices were resetting before sending the UpdateDone ACK to the server, leaving it in a limbo OTA process state for 16 minutes.  During this 16 minutes, the device APIs were blocked (no function calls, etc..)
- Event loop error = 3 (INVALID_STATE) when working around the reset too soon issue with a "Delay 5 seconds before resetting after OTA update" fix.

### Solution

- Instead of 50 chunks at a time, only 40 are requested (reduces lossy behavior of Cat-M1)
- The Particle Cloud also needs to initially send 40 instead of 50 chunks (currently deployed).
- Multiple UpdateDone replies reduced to one (removes errors)
- Multiple ChunksMissed replies reduced to one (removes errors)
- 3 second timeout removed (Server is now very persistent about sending UpdateDone after each round of Chunks).
- Wait for confirmable messages to be sent (fixes resetting too soon which was causing the server to hang around for 16 minutes)
- If a CHUNK or UPDATE_DONE CoAP message is received when we don't expect it, instead of forcing an INVALID_STATE error, simply throw NO_ERROR to give a silent error (removes errors)

### Steps to Test

- Enable `Serial1LogHander logHandler(115200, LOG_LEVEL_ALL);` in the Tinker app.
- Program a E Series LTE device with a monolithic image of that modified Tinker app from this branch to prevent it from being overwritten by modular firmware OTA'd to it.
- OTA a system-part2-0.8.0-rc.8-electron.bin to it and watch it's logging output on the TX pin.
- Also try the included Test App:
   - #define DELAY_RESET_5_SECONDS
   - #define MORE_THAN_40_CHUNKS
   - comment out both ^
- Test on LTE E Series, U260 Electron G350 Electron, U201 E Series, Photon, P1.

### Test App

```cpp
/*
 ******************************************************************************
  Copyright (c) 2015 Particle Industries, Inc.  All rights reserved.

  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public
  License as published by the Free Software Foundation, either
  version 3 of the License, or (at your option) any later version.

  This program is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  Lesser General Public License for more details.

  You should have received a copy of the GNU Lesser General Public
  License along with this program; if not, see <http://www.gnu.org/licenses/>.
  ******************************************************************************
 */

/* Includes ------------------------------------------------------------------*/
#include "application.h"
#include "stdarg.h"

PRODUCT_ID(PLATFORM_ID);
PRODUCT_VERSION(3);

/* Function prototypes -------------------------------------------------------*/
int tinkerDigitalRead(String pin);
int tinkerDigitalWrite(String command);
int tinkerAnalogRead(String pin);
int tinkerAnalogWrite(String command);

Serial1LogHandler logHandler(115200, LOG_LEVEL_ALL);

STARTUP(System.enable(SYSTEM_FLAG_WIFITESTER_OVER_SERIAL1));
STARTUP(System.enableFeature(FEATURE_WIFITESTER));

// COMMENT/UNCOMMENT for different options
// #define DELAY_RESET_5_SECONDS
#define MORE_THAN_40_CHUNKS

SYSTEM_MODE(AUTOMATIC);
SYSTEM_THREAD(ENABLED);

// let's get our binary larger than 40 chunks worth of data!
#define TOTAL_WASTE (2000)
const uint32_t waste_of_flash[TOTAL_WASTE] = {0};
uint32_t waste_of_ram[TOTAL_WASTE] = {0};

void systemEventHandler(system_event_t event, int data) {
    // Log.info("EVENT_H: %lu EVENT_L: %lu DATA: %d", (uint32_t)(event>>32), (uint32_t)event, data);

    // RESET PENDING
    if (event == reset_pending) {
        Log.info("\nDELAYING RESET\n");
        static uint32_t reset_timer = millis();
        while (millis() - reset_timer < 5000) {
            Particle.process();
        }
        Log.info("\nENABLE RESET\n");
        delay(500);
        System.enableReset();
    }
}

/* This function is called once at start up ----------------------------------*/
void setup()
{
#ifdef DELAY_RESET_5_SECONDS
    System.disableReset();
    System.on(reset_pending, systemEventHandler);
#endif

    //Setup the Tinker application here

    //Register all the Tinker functions
    Particle.function("digitalread", tinkerDigitalRead);
    Particle.function("digitalwrite", tinkerDigitalWrite);

    Particle.function("analogread", tinkerAnalogRead);
    Particle.function("analogwrite", tinkerAnalogWrite);

#ifdef MORE_THAN_40_CHUNKS
    for (uint32_t x=0; x<TOTAL_WASTE; x++) {
        waste_of_ram[x] = waste_of_flash[x];
    }
#endif
}

/* This function loops forever --------------------------------------------*/
void loop()
{
    //This will run in a loop
}

/*******************************************************************************
 * Function Name  : tinkerDigitalRead
 * Description    : Reads the digital value of a given pin
 * Input          : Pin
 * Output         : None.
 * Return         : Value of the pin (0 or 1) in INT type
                    Returns a negative number on failure
 *******************************************************************************/
int tinkerDigitalRead(String pin)
{
    //convert ascii to integer
    int pinNumber = pin.charAt(1) - '0';
    //Sanity check to see if the pin numbers are within limits
    if (pinNumber < 0 || pinNumber > 7) return -1;

    if(pin.startsWith("D"))
    {
        pinMode(pinNumber, INPUT_PULLDOWN);
        return digitalRead(pinNumber);
    }
    else if (pin.startsWith("A"))
    {
        pinMode(pinNumber+10, INPUT_PULLDOWN);
        return digitalRead(pinNumber+10);
    }
#if Wiring_Cellular
    else if (pin.startsWith("B"))
    {
        if (pinNumber > 5) return -3;
        pinMode(pinNumber+24, INPUT_PULLDOWN);
        return digitalRead(pinNumber+24);
    }
    else if (pin.startsWith("C"))
    {
        if (pinNumber > 5) return -4;
        pinMode(pinNumber+30, INPUT_PULLDOWN);
        return digitalRead(pinNumber+30);
    }
#endif
    return -2;
}

/*******************************************************************************
 * Function Name  : tinkerDigitalWrite
 * Description    : Sets the specified pin HIGH or LOW
 * Input          : Pin and value
 * Output         : None.
 * Return         : 1 on success and a negative number on failure
 *******************************************************************************/
int tinkerDigitalWrite(String command)
{
    bool value = 0;
    //convert ascii to integer
    int pinNumber = command.charAt(1) - '0';
    //Sanity check to see if the pin numbers are within limits
    if (pinNumber < 0 || pinNumber > 7) return -1;

    if(command.substring(3,7) == "HIGH") value = 1;
    else if(command.substring(3,6) == "LOW") value = 0;
    else return -2;

    if(command.startsWith("D"))
    {
        pinMode(pinNumber, OUTPUT);
        digitalWrite(pinNumber, value);
        return 1;
    }
    else if(command.startsWith("A"))
    {
        pinMode(pinNumber+10, OUTPUT);
        digitalWrite(pinNumber+10, value);
        return 1;
    }
#if Wiring_Cellular
    else if(command.startsWith("B"))
    {
        if (pinNumber > 5) return -4;
        pinMode(pinNumber+24, OUTPUT);
        digitalWrite(pinNumber+24, value);
        return 1;
    }
    else if(command.startsWith("C"))
    {
        if (pinNumber > 5) return -5;
        pinMode(pinNumber+30, OUTPUT);
        digitalWrite(pinNumber+30, value);
        return 1;
    }
#endif
    else return -3;
}

/*******************************************************************************
 * Function Name  : tinkerAnalogRead
 * Description    : Reads the analog value of a pin
 * Input          : Pin
 * Output         : None.
 * Return         : Returns the analog value in INT type (0 to 4095)
                    Returns a negative number on failure
 *******************************************************************************/
int tinkerAnalogRead(String pin)
{
    //convert ascii to integer
    int pinNumber = pin.charAt(1) - '0';
    //Sanity check to see if the pin numbers are within limits
    if (pinNumber < 0 || pinNumber > 7) return -1;

    if(pin.startsWith("D"))
    {
        return -3;
    }
    else if (pin.startsWith("A"))
    {
        return analogRead(pinNumber+10);
    }
#if Wiring_Cellular
    else if (pin.startsWith("B"))
    {
        if (pinNumber < 2 || pinNumber > 5) return -3;
        return analogRead(pinNumber+24);
    }
#endif
    return -2;
}

/*******************************************************************************
 * Function Name  : tinkerAnalogWrite
 * Description    : Writes an analog value (PWM) to the specified pin
 * Input          : Pin and Value (0 to 255)
 * Output         : None.
 * Return         : 1 on success and a negative number on failure
 *******************************************************************************/
int tinkerAnalogWrite(String command)
{
    String value = command.substring(3);

    if(command.substring(0,2) == "TX")
    {
        pinMode(TX, OUTPUT);
        analogWrite(TX, value.toInt());
        return 1;
    }
    else if(command.substring(0,2) == "RX")
    {
        pinMode(RX, OUTPUT);
        analogWrite(RX, value.toInt());
        return 1;
    }

    //convert ascii to integer
    int pinNumber = command.charAt(1) - '0';
    //Sanity check to see if the pin numbers are within limits

    if (pinNumber < 0 || pinNumber > 7) return -1;

    if(command.startsWith("D"))
    {
        pinMode(pinNumber, OUTPUT);
        analogWrite(pinNumber, value.toInt());
        return 1;
    }
    else if(command.startsWith("A"))
    {
        pinMode(pinNumber+10, OUTPUT);
        analogWrite(pinNumber+10, value.toInt());
        return 1;
    }
    else if(command.substring(0,2) == "TX")
    {
        pinMode(TX, OUTPUT);
        analogWrite(TX, value.toInt());
        return 1;
    }
    else if(command.substring(0,2) == "RX")
    {
        pinMode(RX, OUTPUT);
        analogWrite(RX, value.toInt());
        return 1;
    }
#if Wiring_Cellular
    else if (command.startsWith("B"))
    {
        if (pinNumber > 3) return -3;
        pinMode(pinNumber+24, OUTPUT);
        analogWrite(pinNumber+24, value.toInt());
        return 1;
    }
    else if (command.startsWith("C"))
    {
        if (pinNumber < 4 || pinNumber > 5) return -4;
        pinMode(pinNumber+30, OUTPUT);
        analogWrite(pinNumber+30, value.toInt());
        return 1;
    }
#endif
    else return -2;
}
```

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [N/A] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
