### PR TITLE
[LTE/Electron] eDRX & Power Saving mode disabled by default

### DIFF
--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -1504,6 +1504,12 @@ MDM_IP MDMParser::join(const char* apn /*= NULL*/, const char* username /*= NULL
             sendFormated("AT+UPSND=" PROFILE ",0\r\n");
             if (RESP_OK != waitFinalResp(_cbUPSND, &_ip))
                 goto failure;
+            // Get the primary DNS server (logs only), don't fail on error.
+            sendFormated("AT+UPSND=" PROFILE ",1\r\n");
+            waitFinalResp();
+            // Get the secondary DNS server (logs only), don't fail on error.
+            sendFormated("AT+UPSND=" PROFILE ",2\r\n");
+            waitFinalResp();
         }
         UNLOCK();
         _attached = true;  // GPRS

--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -786,6 +786,23 @@ bool MDMParser::init(DevStatus* status)
             _dev.lpm = LPM_ACTIVE;
         }
     }
+    if (_dev.dev == DEV_SARA_R410) {
+        // Force eDRX mode to be disabled
+        // 18/23 hardware doesn't seem to be disabled by default
+        sendFormated("AT+CEDRXS=0\r\n");
+        if (RESP_OK != waitFinalResp())
+            goto failure;
+        sendFormated("AT+CEDRXS?\r\n");
+        if (RESP_OK != waitFinalResp())
+            goto failure;
+        // Force Power Saving mode to be disabled for good measure
+        sendFormated("AT+CPSMS=0\r\n");
+        if (RESP_OK != waitFinalResp())
+            goto failure;
+        sendFormated("AT+CPSMS?\r\n");
+        if (RESP_OK != waitFinalResp())
+            goto failure;
+    }
     // Setup SMS in text mode
     sendFormated("AT+CMGF=1\r\n");
     if (RESP_OK != waitFinalResp())


### PR DESCRIPTION
### Problem

eDRX is enabled by default on production u-Blox modules, and it causes a variable lag in the network data transmissions that we do not account for at this time.

### Solution

1. Force eDRX to be disabled
2. Force Power Saving mode to be disabled (for good measure)

This PR also adds some logs for 2G/3G devices that query the modem for the DNS servers used.  Right now there are no high level APIs implemented, but later we can add support for `Cellular.dnsServerIP()` like was done for WiFi devices: https://docs.particle.io/reference/firmware/photon/#dnsserverip-

### Steps to Test

Manual testing required:
1. Flash LTE device with this system firmware and tinker
2. Make a function call `particle call <device> digitalwrite D7,LOW`
3. It should return 1 if successful
4. Wait 3 minutes
5. Make a function call `particle call <device> digitalwrite D7,LOW`
6. It should return 1 if successful

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [N/A] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
