### PR TITLE
Fixes recursive semaphore lock timeout [ch21928]

### DIFF
--- a/hal/src/electron/core_hal.c
+++ b/hal/src/electron/core_hal.c
@@ -203,6 +203,7 @@ static void init_malloc_mutex(void)
 
 void __malloc_lock(void* ptr)
 {
+    SPARK_ASSERT(!HAL_IsISR());
     if (malloc_mutex) {
         if (!xSemaphoreTakeRecursive(malloc_mutex, MALLOC_LOCK_TIMEOUT_MS)) {
             PANIC(SemaphoreLockTimeout,"Semaphore Lock Timeout");
@@ -213,8 +214,10 @@ void __malloc_lock(void* ptr)
 
 void __malloc_unlock(void* ptr)
 {
-    if (malloc_mutex)
+    SPARK_ASSERT(!HAL_IsISR());
+    if (malloc_mutex) {
         xSemaphoreGiveRecursive(malloc_mutex);
+    }
 }
 
 void application_task_start(void* arg)

--- a/hal/src/electron/core_hal.c
+++ b/hal/src/electron/core_hal.c
@@ -30,6 +30,7 @@
 #include "task.h"
 #include "semphr.h"
 #include "dct_hal.h"
+#include "service_debug.h"
 
 /* Private typedef ----------------------------------------------------------*/
 
@@ -187,7 +188,8 @@ void HAL_Core_Restore_Interrupt(IRQn_Type irqn) {
 
 
 static TaskHandle_t  app_thread_handle;
-#define APPLICATION_STACK_SIZE 6144
+#define APPLICATION_STACK_SIZE (6144)
+#define MALLOC_LOCK_TIMEOUT_MS (60000) // This is defined in "ticks" and each tick is 1ms
 
 /**
  * The mutex to ensure only one thread manipulates the heap at a given time.
@@ -201,8 +203,12 @@ static void init_malloc_mutex(void)
 
 void __malloc_lock(void* ptr)
 {
-    if (malloc_mutex)
-        while (!xSemaphoreTakeRecursive(malloc_mutex, 0xFFFFFFFF)) {}
+    if (malloc_mutex) {
+        if (!xSemaphoreTakeRecursive(malloc_mutex, MALLOC_LOCK_TIMEOUT_MS)) {
+            PANIC(SemaphoreLockTimeout,"Semaphore Lock Timeout");
+            while (1);
+        }
+    }
 }
 
 void __malloc_unlock(void* ptr)

--- a/services/inc/panic_codes.h
+++ b/services/inc/panic_codes.h
@@ -27,3 +27,5 @@ def_panic_codes(Software,RGB_COLOR_RED,InvalidCase)
 def_panic_codes(Software,RGB_COLOR_RED,PureVirtualCall)
 
 def_panic_codes(System,RGB_COLOR_RED,StackOverflow)
+
+def_panic_codes(System,RGB_COLOR_RED,SemaphoreLockTimeout)


### PR DESCRIPTION
### Problem

If the system thread or application thread gets stuck attempting to dynamically allocation memory, and the opposing thread subsequently also attempts to allocate memory, the recursive semaphore will deadlock.  This recursive semaphore does have a timeout, but was set to approximately 1193 hours, so basically it would be stalled forever.

### Solution

- The semaphore lock timeout was changed to 60 seconds, and a new PANIC SOS 14 "Semaphore Lock Timeout" was added to note this condition and reset the device.  The PANIC code is also saved in the last Reset Reason.
- Additionally SPARK_ASSERT() was added to ensure __malloc_lock/unlock is not called from an ISR.

### Steps to Test

This semaphore deadlock condition is so rare, I could not create a simple user app to force it to occur.  The new PANIC was tested just by adding the panic to a user app, essentially forcing the panic code.

### FWIW, Here's my test app (that doesn't cause the issue)

```c
#include "Particle.h"

SYSTEM_THREAD(ENABLED);

SerialLogHandler logHandler(115200, LOG_LEVEL_ALL);

volatile bool run = true;

Thread *genericAllocatorThread;
Thread *stringAllocatorThread;
Thread *memoryLeakThread;
Thread *recursiveMallocThread;

void createAStringFromThread() {
    String string1 = String("A fun") + String("new string") + String("from thread! OMG omg omg omg let's make it longer!!!!!");
    // Serial.println(string1.c_str());
}

void createAStringFromApp() {
    String string2 = String("A fun") + String("new string") + String("from app! OMG omg omg omg let's make it longer!!!!!");
    // Serial.println(string2.c_str());
}

void createAStringRecursively() {
    String string2 = String("A fun") + String("new string") + String("recursively! OMG omg omg omg let's make it longer!!!!!");
    delay(5000);

    // forever!!
    createAStringRecursively();
}

void semaphoreLockTest() {

    // Call generic malloc in one thread
    genericAllocatorThread = new Thread("generic-allocator", [&]
    {
        while(run)
        {
            void *ptr = malloc(100);
            free(ptr);
        }
    });

    // Call String use of malloc in another thread
    stringAllocatorThread = new Thread("string-allocator", [&]
    {
        while(run)
        {
            createAStringFromThread();
        }
    });

    // Memory leak in another thread
    memoryLeakThread = new Thread("memory-leak", [&]
    {
        while(run)
        {
            static uint32_t last = millis();
            if (millis() - last >= 500) {
                last = millis();
                String *ptr1 = new String("The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!!");
                String *ptr2 = new String("The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!! The faucet is on!!!");
                delete ptr1;
                // String *ptr3 = new String("The faucet is on!!!");
                // String *ptr4 = new String("The faucet is on!!!");
                // delete ptr4;
            }
        }
    });

    // Create a string recursively (although this isn't a true recursive malloc operation) ... basically it's another memory leak
    recursiveMallocThread = new Thread("recursive-malloc", [&]
    {
        while(run)
        {
            createAStringRecursively();
            while(1); // should never get here
        }
    });
}

bool once = false;
void setup() {
    pinMode(D7, OUTPUT);

    // Kick off the test before we are connected, this usually results in handshake errors or running out of memory before we get connected.
    // semaphoreLockTest();
    // once = true;
}

void loop() {
    static uint32_t last_memory_update = millis();
    static runtime_info_t info;
    if (info.size == 0) {
        info.size = sizeof(info);
    }

    // If not already running from setup(), enable after we connect to the cloud.
    if (!once && Particle.connected()) {
        once = true;
        semaphoreLockTest();
    }

    // Every second log the memory stats
    if (millis() - last_memory_update >= 1000UL) {
        last_memory_update = millis();
        digitalWrite(D7, !digitalRead(D7));
        HAL_Core_Runtime_Info(&info, nullptr);
        Serial.printlnf("\r\n\r\n||| mem:%lu, heap:%lu\r\n", info.freeheap, info.largest_free_block_heap);
    }

    // as fast as possible!
    if (run) {
        createAStringFromApp();
    }

    // End the test at 3 minutes
    if (millis() > 180000) {
        run = false;

        // No assertion needed. If the test finishes there was no deadlock
        genericAllocatorThread->dispose();
        stringAllocatorThread->dispose();
        memoryLeakThread->dispose();
        recursiveMallocThread->dispose();

        Serial.println("\r\n\r\n||| Test Passed!!!\r\n");

        // Optionally force this new Panic Code just as a test
        PANIC(SemaphoreLockTimeout,"Semaphore Lock Timeout");

        while(1) {
            Particle.process();
        }
    }

}
```

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation (Add new PANIC code)
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
