### PR TITLE
Do not check and lock bootloader sector write protection on every boot [ch17416]

### DIFF
--- a/hal/src/stm32f2xx/core_hal_stm32f2xx.c
+++ b/hal/src/stm32f2xx/core_hal_stm32f2xx.c
@@ -405,7 +405,6 @@ void HAL_Core_Setup(void) {
     if (bootloader_update_if_needed()) {
         HAL_Core_System_Reset();
     }
-    HAL_Bootloader_Lock(true);
 
     HAL_save_device_id(DCT_DEVICE_ID_OFFSET);
 


### PR DESCRIPTION
### Problem

Checking and locking the bootloader sector write protection (if needed) on every boot could be contributing to flash memory corruption, although no testing has shown this to occur. It has only occurred naturally in the wild.  See references.

### Solution

Do not check and lock bootloader write protect on every boot

The idea being that a power glitch could result in the read of sector 0 write protection bits being misinterpreted as unprotected, which would unlock the Option Bytes register to change these bits to be protected.  While writing to Option Bytes register, if power is lost or the MCU is reset, this can result in Read Protection level being set to 1. This is fairly well understood and easy to reproduce, so not attempting to write protect the bootloader on every boot is a great mitigation technique to avoiding RPD level 1.  

We still do write protect the bootloader at the time of MFG. and also on future bootloader updates.  Read Protection level 1 is not really harmful though and the device can function normally (minus debugging tool support in this mode).  The real issue is if Read Protection level 1 is subsequently set back to level 0, which causes the MCU to self-mass-erase.  This is a fairly difficult thing to do since RDP level 0 requires 0xAA to be written to the Option Bytes register, and is not something done in system firmware anywhere.

### Steps to Test

- Compile a test application with debugging enabled to make using a debugger easier
- firmware/modules $ make clean all -s PLATFORM=electron COMPILE_LTO=n USE_SWD_JTAG=y DEBUG_BUILD=y APP=tinker program-dfu
- run the `unprotect` command below
- run the `flashinfo` command below and verify that the first sector is unprotected
- Reset the device
- run the `flashinfo` command below and verify that the first sector is still unprotected
- Flash a bootloader via OTA or YModem
- run the `flashinfo` command below and verify that the first sector is now **protected**
- Reset the device
- run the `flashinfo` command below and verify that the first sector is still protected

#### Some bash functions to make working with OpenOCD easier

```
unprotect() {
  openocd -f interface/jlink.cfg \
        -c "transport select swd" \
        -f "target/stm32f2x.cfg" \
	-c "init" \
	-c "reset init" \
	-c "stm32f2x unlock 0" \
	-c "flash protect 0 0 last off" \
	-c "reset run" \
	-c "shutdown"
}

flashinfo() {
  openocd -f interface/jlink.cfg \
        -c "transport select swd" \
        -f "target/stm32f2x.cfg" \
        -c "init" \
        -c "reset init" \
        -c "flash info 0" \
        -c "reset" \
        -c "shutdown"
}
```

### References

https://community.particle.io/t/bug-bounty-electron-not-booting-after-battery-discharges-completely/25043

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] [N/A] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
