### PR TITLE
Fix WiFi credentials clear event not being fired

### DIFF
--- a/system/src/system_network_wifi.h
+++ b/system/src/system_network_wifi.h
@@ -184,6 +184,8 @@ public:
 
     bool clear_credentials() override
     {
+        system_notify_event(network_credentials, network_credentials_cleared);
+
         return wlan_clear_credentials() == 0;
     }
 


### PR DESCRIPTION
### Problem

A WiFi credentials event should be fired when a user calls WiFi.clear_credentials(). It doesn't currently happen.

### Solution

A system event is triggered, when a user clears WiFi credentials.

### Example App

```c
void credentialsChanged() {
    Serial.println("Credentials changed");
}

SYSTEM_MODE(AUTOMATIC);

void setup() {
    Serial.begin(9600);
    System.on(network_credentials, credentialsChanged);
}

void loop() {
    Serial.println("Clearing credentials");
    WiFi.clearCredentials();
    delay(1000);
}
```

### References

[#1570](https://github.com/particle-iot/firmware/issues/1570)

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)