### PR TITLE
[Electron/LTE] Power Manager Watchdog Timer Fix

### DIFF
--- a/system/src/system_power.cpp
+++ b/system/src/system_power.cpp
@@ -16,6 +16,9 @@ BatteryChargeDiagnosticData::BatteryChargeDiagnosticData(uint16_t id, const char
 }
 
 int BatteryChargeDiagnosticData::get(IntType& val) {
+    if (g_batteryState == BATTERY_STATE_DISCONNECTED) {
+        return SYSTEM_ERROR_INVALID_STATE;
+    }
     FuelGauge fuel(true);
     float soc = fuel.getNormalizedSoC();
     val = particle::FixedPointUQ<8, 8>(soc);

--- a/system/src/system_power.cpp
+++ b/system/src/system_power.cpp
@@ -42,6 +42,9 @@ void system_power_management_sleep(bool sleep) {
 
 #else /* Wiring_Cellular != 1 */
 
+void system_power_management_init() {
+}
+
 void system_power_management_sleep(bool sleep) {
 }
 

--- a/system/src/system_power_manager.cpp
+++ b/system/src/system_power_manager.cpp
@@ -109,6 +109,12 @@ void PowerManager::handleUpdate() {
     }
   }
 
+  if (g_batteryState == BATTERY_STATE_DISCONNECTED && state == BATTERY_STATE_NOT_CHARGING &&
+      chargingDisabledTimestamp_) {
+    // We are aware of the fact that charging has been disabled, stay in disconnected state
+    state = BATTERY_STATE_DISCONNECTED;
+  }
+
   const bool lowBat = fuel.getAlert();
   handleStateChange(g_batteryState, state, lowBat);
 
@@ -355,6 +361,8 @@ void PowerManager::checkWatchdog() {
   if (g_batteryState == BATTERY_STATE_DISCONNECTED &&
       ((millis() - chargingDisabledTimestamp_) >= DEFAULT_WATCHDOG_TIMEOUT)) {
     // Re-enable charging, do not run DPDM detection
+    LOG_DEBUG(TRACE, "re-enabling charging");
+    chargingDisabledTimestamp_ = 0;
     initDefault(false);
   }
 }

--- a/system/src/system_power_manager.h
+++ b/system/src/system_power_manager.h
@@ -10,7 +10,7 @@ static const system_tick_t DEFAULT_FAULT_WINDOW = 1000;
 static const uint32_t DEFAULT_FAULT_COUNT_THRESHOLD = 5;
 static const system_tick_t DEFAULT_FAULT_SUPPRESSION_PERIOD = 60000;
 static const system_tick_t DEFAULT_QUEUE_WAIT = 1000;
-static const system_tick_t DEFAULT_WATCHDOG_TIMEOUT = 40000;
+static const system_tick_t DEFAULT_WATCHDOG_TIMEOUT = 60000;
 
 class PowerManager {
 public:

--- a/system/src/system_power_manager.h
+++ b/system/src/system_power_manager.h
@@ -10,6 +10,7 @@ static const system_tick_t DEFAULT_FAULT_WINDOW = 1000;
 static const uint32_t DEFAULT_FAULT_COUNT_THRESHOLD = 5;
 static const system_tick_t DEFAULT_FAULT_SUPPRESSION_PERIOD = 60000;
 static const system_tick_t DEFAULT_QUEUE_WAIT = 1000;
+static const system_tick_t DEFAULT_WATCHDOG_TIMEOUT = 40000;
 
 class PowerManager {
 public:
@@ -26,11 +27,12 @@ private:
   static void isrHandler();
   void update();
   void handleUpdate();
-  void initDefault();
+  void initDefault(bool dpdm = true);
   void handleStateChange(battery_state_t from, battery_state_t to, bool low);
   battery_state_t handlePossibleFault(battery_state_t from, battery_state_t to);
   void handlePossibleFaultLoop();
   void logStat(uint8_t stat, uint8_t fault);
+  void checkWatchdog();
 
 private:
   static volatile bool update_;
@@ -41,6 +43,7 @@ private:
   uint32_t possibleFaultCounter_ = 0;
   system_tick_t possibleFaultTimestamp_ = 0;
   bool lowBatEnabled_ = true;
+  system_tick_t chargingDisabledTimestamp_ = 0;
 };
 
 

--- a/wiring/src/spark_wiring_power.cpp
+++ b/wiring/src/spark_wiring_power.cpp
@@ -285,7 +285,7 @@ uint16_t PMIC::getInputCurrentLimit(void) {
         3000
     };
     byte raw = readInputSourceRegister();
-    raw &= 0x03;
+    raw &= 0x07;
     return mapping[raw];
 }
 


### PR DESCRIPTION
### Problem

Modem on Electron/LTE turn off unexpectedly during initialization when powered from a USB Host only (no battery).

After an investigation it was discovered that the PMIC watchdog causes current limit to drop to 100mA temporarily which causes the modem to stop responding to AT commands.

### Solution

Power Manager no longer using PMIC watchdog because it causes current limit to drop to 100mA temporarily when it expires

**Workaround:** For 0.8.0-rc.1 ~ 0.8.0-rc.11, add `PMIC().disableCharging()` to `setup()` when no battery is used.

### Steps to Test

1. Program an Electron with this PR's firmware
2. Leave the battery disconnected, powered via USB only
3. The system will check for a disconnected battery every 40 seconds
4. The device should stay connected, AT commands should continue to work.
5. Compared to 0.8.0-rc.11 system firmware, after 40 seconds of the battery being disconnected, the PMIC watchdog causes current limit to drop to 100mA temporarily which causes the modem to stop responding to AT commands.

### References

Fixes #1548 

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] (N/A) Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
