### PR TITLE
[Boron] Fixes a race condition on startup from cold boot (U201)

### DIFF
--- a/hal/src/boron/network/sara_ncp_client.cpp
+++ b/hal/src/boron/network/sara_ncp_client.cpp
@@ -30,6 +30,7 @@
 #include "gpio_hal.h"
 #include "timer_hal.h"
 #include "delay_hal.h"
+#include "core_hal.h"
 
 #include "stream_util.h"
 
@@ -1033,6 +1034,23 @@ int SaraNcpClient::modemPowerOn() const {
 }
 
 int SaraNcpClient::modemPowerOff() const {
+    static std::once_flag f;
+    std::call_once(f, [this]() {
+        if (ncpId() != MESH_NCP_SARA_R410 && modemPowerState()) {
+            // U201 will auto power-on when it detects a rising VIN
+            // If we perform a power-off sequence immediately after it just started
+            // to power-on, it will not be detected. Add an artificial delay here.
+            int reason;
+            if (!HAL_Core_Get_Last_Reset_Info(&reason, nullptr, nullptr) &&
+                    (reason == RESET_REASON_POWER_DOWN || reason == RESET_REASON_POWER_BROWNOUT)) {
+                auto now = HAL_Timer_Get_Milli_Seconds();
+                if (now < 5000) {
+                    HAL_Delay_Milliseconds(5000 - now);
+                }
+            }
+        }
+    });
+
     if (modemPowerState()) {
         LOG(TRACE, "Powering modem off");
         // Important! We need to disable voltage translator here


### PR DESCRIPTION
### Problem

U201 will auto power-on when it detects a rising VIN. If we perform a power-off sequence immediately after it just started to power-on, it will not be detected and we incur a 10 second delay (power-off timeout).

### Solution

- Add an artificial delay when cold boot is detected
- This PR also fixes reset reason (`RESET_REASON_POWER_DOWN`/`RESET_REASON_POWER_BROWNOUT` can in fact be supported on NRF52840 devices)

### Steps to Test

- Cold boot a 3G Boron
- Take a look at the logs, there shouldn't be any `[hal] ERROR: Failed to power off modem` lines

### Example App

N/A

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
