### PR TITLE
[Mesh] Network system events

### DIFF
--- a/system/src/system_listening_mode.h
+++ b/system/src/system_listening_mode.h
@@ -27,6 +27,7 @@
 #include "active_object.h"
 #include "system_setup.h"
 #include <memory>
+#include "system_tick_hal.h"
 
 namespace particle { namespace system {
 
@@ -63,6 +64,8 @@ private:
     std::atomic_bool active_;
 
     std::unique_ptr<SystemSetupConsoleBase> console_;
+    system_tick_t timestampStarted_;
+    system_tick_t timestampUpdate_;
 };
 
 } } /* particle::system */

--- a/system/src/system_network_manager_api.cpp
+++ b/system/src/system_network_manager_api.cpp
@@ -25,7 +25,7 @@
 #include "system_cloud_internal.h"
 #include "system_threading.h"
 #include "system_listening_mode.h"
-
+#include "system_event.h"
 #include "delay_hal.h"
 
 #include "dct.h"
@@ -336,8 +336,13 @@ int network_listen_command(network_handle_t network, network_listen_command_t co
 int network_set_credentials(network_handle_t network, uint32_t, NetworkCredentials* credentials, void*) {
     switch (network) {
 #if HAL_PLATFORM_WIFI
-    case NETWORK_INTERFACE_WIFI_STA:
-        return wlan_set_credentials(credentials);
+    case NETWORK_INTERFACE_WIFI_STA: {
+        auto r = wlan_set_credentials(credentials);
+        if (!r) {
+            system_notify_event(network_credentials, network_credentials_added, credentials);
+        }
+        return r;
+    }
 #endif
     default:
         return SYSTEM_ERROR_INVALID_ARGUMENT;


### PR DESCRIPTION
### Problem

Mesh devices currently do not generate any `network_*` or `setup_*` system events.

### Solution

Fix that :)

**TODO:** Long term, we should revise our network system events and make them per-interface instead.

### Steps to Test

N/A

### Example App

N/A

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
