### PR TITLE
Feature/hal/spi slave

### DIFF
--- a/hal/inc/spi_hal.h
+++ b/hal/inc/spi_hal.h
@@ -123,7 +123,6 @@ int32_t HAL_SPI_DMA_Transfer_Status(HAL_SPI_Interface spi, HAL_SPI_TransferStatu
 // HAL_SPI_Set_Bit_Order, HAL_SPI_Set_Data_Mode and HAL_SPI_Set_Clock_Divider in one go
 // to avoid having to reconfigure SPI peripheral 3 times
 int32_t HAL_SPI_Set_Settings(HAL_SPI_Interface spi, uint8_t set_default, uint8_t clockdiv, uint8_t order, uint8_t mode, void* reserved);
-int32_t HAL_SPI_Set_Slave_Buffers(HAL_SPI_Interface spi, void* tx_buffer, void* rx_buffer, uint32_t length);
 
 int32_t HAL_SPI_Acquire(HAL_SPI_Interface spi, void* reserved);
 int32_t HAL_SPI_Release(HAL_SPI_Interface spi, void* reserved);

--- a/hal/inc/spi_hal.h
+++ b/hal/inc/spi_hal.h
@@ -123,6 +123,7 @@ int32_t HAL_SPI_DMA_Transfer_Status(HAL_SPI_Interface spi, HAL_SPI_TransferStatu
 // HAL_SPI_Set_Bit_Order, HAL_SPI_Set_Data_Mode and HAL_SPI_Set_Clock_Divider in one go
 // to avoid having to reconfigure SPI peripheral 3 times
 int32_t HAL_SPI_Set_Settings(HAL_SPI_Interface spi, uint8_t set_default, uint8_t clockdiv, uint8_t order, uint8_t mode, void* reserved);
+int32_t HAL_SPI_Set_Slave_Buffers(HAL_SPI_Interface spi, void* tx_buffer, void* rx_buffer, uint32_t length);
 
 int32_t HAL_SPI_Acquire(HAL_SPI_Interface spi, void* reserved);
 int32_t HAL_SPI_Release(HAL_SPI_Interface spi, void* reserved);

--- a/hal/src/nRF52840/spi_hal.cpp
+++ b/hal/src/nRF52840/spi_hal.cpp
@@ -14,14 +14,20 @@
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, see <http://www.gnu.org/licenses/>.
  */
+#include "logging.h"
+
 #include "nrf_gpio.h"
 #include "nrfx_spim.h"
+#include "nrfx_spis.h"
 #include "spi_hal.h"
 #include "pinmap_hal.h"
 #include "pinmap_impl.h"
-#include "logging.h"
+#include "gpio_hal.h"
 #include "interrupts_hal.h"
 #include "concurrent_hal.h"
+#include "delay_hal.h"
+
+
 
 #define DEFAULT_SPI_MODE        SPI_MODE_MASTER
 #define DEFAULT_DATA_MODE       SPI_MODE3
@@ -29,7 +35,8 @@
 #define DEFAULT_SPI_CLOCK       SPI_CLOCK_DIV256
 
 typedef struct {
-    const nrfx_spim_t                   *instance;
+    const nrfx_spim_t                   *master;
+    const nrfx_spis_t                   *slave;
     app_irq_priority_t                  priority;
     uint8_t                             ss_pin;
     uint8_t                             sck_pin;
@@ -41,49 +48,83 @@ typedef struct {
     uint8_t                             bit_order;
     uint32_t                            clock;
 
-    volatile HAL_SPI_DMA_UserCallback   user_callback;
+    volatile uint8_t                    spi_ss_state;
+    void                                *slave_tx_buf;
+    void                                *slave_rx_buf;
+    uint32_t                            slave_buf_length;
+
+    HAL_SPI_DMA_UserCallback            spi_dma_user_callback;
+    HAL_SPI_Select_UserCallback         spi_select_user_callback;
 
     bool                                enabled;
     volatile bool                       transmitting;
-    uint16_t                            transfer_length;
+    volatile uint16_t                   transfer_length;
 
     os_mutex_recursive_t                mutex;
 } nrf5x_spi_info_t;
 
-static const nrfx_spim_t m_spi2 = NRFX_SPIM_INSTANCE(2);
-static const nrfx_spim_t m_spi3 = NRFX_SPIM_INSTANCE(3);
+static const nrfx_spim_t m_spim2 = NRFX_SPIM_INSTANCE(2);
+static const nrfx_spim_t m_spim3 = NRFX_SPIM_INSTANCE(3);
+static const nrfx_spis_t m_spis2 = NRFX_SPIS_INSTANCE(2);
+
 static nrf5x_spi_info_t m_spi_map[TOTAL_SPI] = {
-    {&m_spi3, APP_IRQ_PRIORITY_HIGH, NRFX_SPIM_PIN_NOT_USED, SCK, MOSI, MISO},
-    {&m_spi2, APP_IRQ_PRIORITY_HIGH, NRFX_SPIM_PIN_NOT_USED, D2, D3, D4},
+    {&m_spim3, NULL, APP_IRQ_PRIORITY_HIGH, NRFX_SPIM_PIN_NOT_USED, SCK, MOSI, MISO}, // TODO: SPI3 doesn't support SPI slave mode
+    {&m_spim2, &m_spis2, APP_IRQ_PRIORITY_HIGH, NRFX_SPIM_PIN_NOT_USED, D2, D3, D4},  // TODO: Change pin number
 };
 
-static void spi_event_handler(nrfx_spim_evt_t const * p_event,
-                              void *                  p_context)
-{
-    if (p_event->type == NRFX_SPIM_EVENT_DONE)
-    {
+static void spi_master_event_handler(nrfx_spim_evt_t const * p_event, void * p_context) {
+    if (p_event->type == NRFX_SPIM_EVENT_DONE) {
+        // LOG_DEBUG(TRACE, ">> spi: rx: %d, tx: %d", p_event->xfer_desc.tx_length, p_event->xfer_desc.rx_length);
         int spi = (int)p_context;
         m_spi_map[spi].transmitting = false;
 
-        if (m_spi_map[spi].user_callback)
-        {
-            (*m_spi_map[spi].user_callback)();
+        if (m_spi_map[spi].spi_dma_user_callback) {
+            (*m_spi_map[spi].spi_dma_user_callback)();
         }
     }
 }
 
-static inline nrf_spim_frequency_t get_nrf_spi_frequency(HAL_SPI_Interface spi, uint8_t clock_div)
-{
-    switch (clock_div)
-    {
-        case SPI_CLOCK_DIV2:
-            if (spi == HAL_SPI_INTERFACE1)
-            {
+void spi_slave_event_handler(nrfx_spis_evt_t const * p_event, void * p_context) {
+    int spi = (int) p_context;
+
+    if (p_event->evt_type == NRFX_SPIS_XFER_DONE) {
+        m_spi_map[spi].transfer_length = p_event->rx_amount;
+
+        if (p_event->rx_amount) {
+            if (m_spi_map[spi].spi_dma_user_callback) {
+                (*m_spi_map[spi].spi_dma_user_callback)();
+            }
+        }
+        // LOG_DEBUG(TRACE, ">> spi: rx: %d, tx: %d", p_event->rx_amount, p_event->tx_amount);
+
+        // Reset spi slave data buffer
+        SPARK_ASSERT(nrfx_spis_buffers_set(m_spi_map[spi].slave, 
+                                        (uint8_t *)m_spi_map[spi].slave_tx_buf, 
+                                        m_spi_map[spi].slave_buf_length, 
+                                        (uint8_t *)m_spi_map[spi].slave_rx_buf, 
+                                        m_spi_map[spi].slave_buf_length) == NRF_SUCCESS);
+    } else if (p_event->evt_type == NRFX_SPIS_BUFFERS_SET_DONE) {
+        // LOG_DEBUG(TRACE, ">> NRFX_SPIS_BUFFERS_SET_DONE");
+    }
+}
+
+static void HAL_SPI_SS_Handler(void *data) {
+    int spi = (int)data;
+    uint8_t state = !HAL_GPIO_Read(m_spi_map[spi].ss_pin);
+    m_spi_map[spi].spi_ss_state = state;
+    if (m_spi_map[spi].spi_select_user_callback) {
+        m_spi_map[spi].spi_select_user_callback(state);
+    }
+}
+
+static inline nrf_spim_frequency_t get_nrf_spi_frequency(HAL_SPI_Interface spi, uint8_t clock_div) {
+    switch (clock_div) {
+        case SPI_CLOCK_DIV2: 
+            if (spi == HAL_SPI_INTERFACE1) {
                 return NRF_SPIM_FREQ_32M;
             }
         case SPI_CLOCK_DIV4:
-            if (spi == HAL_SPI_INTERFACE1)
-            {
+            if (spi == HAL_SPI_INTERFACE1) {
                 return NRF_SPIM_FREQ_16M;
             }
         case SPI_CLOCK_DIV8:
@@ -103,10 +144,8 @@ static inline nrf_spim_frequency_t get_nrf_spi_frequency(HAL_SPI_Interface spi, 
     return NRF_SPIM_FREQ_8M;
 }
 
-static inline uint8_t get_nrf_pin_num(uint8_t pin)
-{
-    if (pin >= TOTAL_PINS)
-    {
+static inline uint8_t get_nrf_pin_num(uint8_t pin) {
+    if (pin >= TOTAL_PINS) {
         return NRFX_SPIM_PIN_NOT_USED;
     }
 
@@ -114,62 +153,91 @@ static inline uint8_t get_nrf_pin_num(uint8_t pin)
     return NRF_GPIO_PIN_MAP(PIN_MAP[pin].gpio_port, PIN_MAP[pin].gpio_pin);
 }
 
-static void spi_init(HAL_SPI_Interface spi)
-{
+static void spi_init(HAL_SPI_Interface spi, SPI_Mode mode) {
     uint32_t err_code;
-    static const nrf_spim_mode_t nrf_spi_mode[4] = {NRF_SPIM_MODE_0, NRF_SPIM_MODE_1, NRF_SPIM_MODE_2, NRF_SPIM_MODE_3};
-    nrfx_spim_config_t spi_config = NRFX_SPIM_DEFAULT_CONFIG;
-    spi_config.sck_pin      = get_nrf_pin_num(m_spi_map[spi].sck_pin);
-    spi_config.mosi_pin     = get_nrf_pin_num(m_spi_map[spi].mosi_pin);
-    spi_config.miso_pin     = get_nrf_pin_num(m_spi_map[spi].miso_pin);
-    spi_config.ss_pin       = get_nrf_pin_num(m_spi_map[spi].ss_pin);
-    spi_config.irq_priority = m_spi_map[spi].priority;
-    spi_config.orc          = 0xFF;
-    spi_config.frequency    = get_nrf_spi_frequency(spi, m_spi_map[spi].clock);
-    spi_config.mode         = nrf_spi_mode[m_spi_map[spi].data_mode];
-    spi_config.bit_order    = (m_spi_map[spi].bit_order == MSBFIRST) ? NRF_SPIM_BIT_ORDER_MSB_FIRST : NRF_SPIM_BIT_ORDER_LSB_FIRST;
 
-    err_code = nrfx_spim_init(m_spi_map[spi].instance, &spi_config, spi_event_handler, (void *)((int)spi));
-    SPARK_ASSERT(err_code == NRF_SUCCESS);
+    if (mode == SPI_MODE_MASTER) {
+        static const nrf_spim_mode_t nrf_spim_mode[4] = {NRF_SPIM_MODE_0, NRF_SPIM_MODE_1, NRF_SPIM_MODE_2, NRF_SPIM_MODE_3};
+        nrfx_spim_config_t spim_config = NRFX_SPIM_DEFAULT_CONFIG;
+        spim_config.sck_pin      = get_nrf_pin_num(m_spi_map[spi].sck_pin);
+        spim_config.mosi_pin     = get_nrf_pin_num(m_spi_map[spi].mosi_pin);
+        spim_config.miso_pin     = get_nrf_pin_num(m_spi_map[spi].miso_pin);
+        spim_config.ss_pin       = NRFX_SPIM_PIN_NOT_USED; 
+        spim_config.irq_priority = m_spi_map[spi].priority;
+        spim_config.orc          = 0xFF;
+        spim_config.frequency    = get_nrf_spi_frequency(spi, m_spi_map[spi].clock);
+        spim_config.mode         = nrf_spim_mode[m_spi_map[spi].data_mode];
+        spim_config.bit_order    = (m_spi_map[spi].bit_order == MSBFIRST) ? NRF_SPIM_BIT_ORDER_MSB_FIRST : NRF_SPIM_BIT_ORDER_LSB_FIRST;
+
+        err_code = nrfx_spim_init(m_spi_map[spi].master, &spim_config, spi_master_event_handler, (void *)((int)spi));
+        SPARK_ASSERT(err_code == NRF_SUCCESS);
+
+        HAL_GPIO_Write(m_spi_map[spi].ss_pin, 1);
+        HAL_Pin_Mode(m_spi_map[spi].ss_pin, OUTPUT);
+    } else {
+        static const nrf_spis_mode_t nrf_spis_mode[4] = {NRF_SPIS_MODE_0, NRF_SPIS_MODE_1, NRF_SPIS_MODE_2, NRF_SPIS_MODE_3};
+        nrfx_spis_config_t spis_config;
+        spis_config.sck_pin      = get_nrf_pin_num(m_spi_map[spi].sck_pin);
+        spis_config.mosi_pin     = get_nrf_pin_num(m_spi_map[spi].mosi_pin);
+        spis_config.miso_pin     = get_nrf_pin_num(m_spi_map[spi].miso_pin);
+        spis_config.csn_pin      = get_nrf_pin_num(m_spi_map[spi].ss_pin);
+        spis_config.csn_pullup   = NRF_GPIO_PIN_PULLUP;
+        spis_config.miso_drive   = NRF_GPIO_PIN_S0S1;
+        spis_config.irq_priority = m_spi_map[spi].priority;
+        spis_config.orc          = 0xFF;
+        spis_config.def          = 0xFF;
+        spis_config.mode         = nrf_spis_mode[m_spi_map[spi].data_mode];
+        spis_config.bit_order    = (m_spi_map[spi].bit_order == MSBFIRST) ? NRF_SPIS_BIT_ORDER_MSB_FIRST : NRF_SPIS_BIT_ORDER_LSB_FIRST;
+
+        err_code = nrfx_spis_init(m_spi_map[spi].slave, &spis_config, spi_slave_event_handler, (void *)((int) spi));
+        SPARK_ASSERT(err_code == NRF_SUCCESS);
+
+        HAL_Pin_Mode(m_spi_map[spi].ss_pin, INPUT_PULLUP);
+        HAL_Interrupts_Attach(m_spi_map[spi].ss_pin, &HAL_SPI_SS_Handler, (void*)(spi), CHANGE, NULL);
+    }
 
     // Set pin function
-    HAL_Set_Pin_Function(m_spi_map[spi].ss_pin, PF_SPI);
     HAL_Set_Pin_Function(m_spi_map[spi].sck_pin, PF_SPI);
     HAL_Set_Pin_Function(m_spi_map[spi].mosi_pin, PF_SPI);
     HAL_Set_Pin_Function(m_spi_map[spi].miso_pin, PF_SPI);
 }
 
-static void spi_uninit(HAL_SPI_Interface spi)
-{
-    nrfx_spim_uninit(m_spi_map[spi].instance);
+static void spi_uninit(HAL_SPI_Interface spi) {
+    if (m_spi_map[spi].spi_mode == SPI_MODE_MASTER) {
+        nrfx_spim_uninit(m_spi_map[spi].master);
+        HAL_Pin_Mode(m_spi_map[spi].ss_pin, PIN_MODE_NONE);
+    } else {
+        nrfx_spis_uninit(m_spi_map[spi].slave);
+        HAL_Interrupts_Detach(m_spi_map[spi].ss_pin);
+        HAL_Pin_Mode(m_spi_map[spi].ss_pin, PIN_MODE_NONE);
+    }
 
-    HAL_Set_Pin_Function(m_spi_map[spi].ss_pin, PF_NONE);
     HAL_Set_Pin_Function(m_spi_map[spi].sck_pin, PF_NONE);
     HAL_Set_Pin_Function(m_spi_map[spi].mosi_pin, PF_NONE);
     HAL_Set_Pin_Function(m_spi_map[spi].miso_pin, PF_NONE);
 }
 
-static void ss_pin_uninit(HAL_SPI_Interface spi)
-{
-    nrf_gpio_cfg_default(get_nrf_pin_num(m_spi_map[spi].ss_pin));
-    
-    HAL_Set_Pin_Function(m_spi_map[spi].ss_pin, PF_NONE);
+static void ss_pin_uninit(HAL_SPI_Interface spi) {
+    uint8_t nrf_pin = get_nrf_pin_num(m_spi_map[spi].ss_pin);
+    if (nrf_pin != NRFX_SPIM_PIN_NOT_USED) {
+        HAL_Pin_Mode(m_spi_map[spi].ss_pin, PIN_MODE_NONE);
+    }
 }
 
-static int spi_tx_rx(HAL_SPI_Interface spi, uint8_t *tx_buf, uint8_t *rx_buf, uint32_t size)
-{
+static uint32_t spi_tx_rx(HAL_SPI_Interface spi, uint8_t *tx_buf, uint8_t *rx_buf, uint32_t size) {
+    // LOG_DEBUG(TRACE, "spi send, size: %d", size);
+
     uint32_t err_code;
     m_spi_map[spi].transmitting = true;
     m_spi_map[spi].transfer_length = size;
 
-    nrfx_spim_xfer_desc_t const spim_xfer_desc =
-    {
+    nrfx_spim_xfer_desc_t const spim_xfer_desc = {
         .p_tx_buffer = tx_buf,
         .tx_length   = tx_buf ? size : 0,
         .p_rx_buffer = rx_buf,
         .rx_length   = rx_buf ? size : 0,
     };
-    err_code = nrfx_spim_xfer(m_spi_map[spi].instance, &spim_xfer_desc, 0);
+    err_code = nrfx_spim_xfer(m_spi_map[spi].master, &spim_xfer_desc, 0);
 
     if (err_code) {
         m_spi_map[spi].transmitting = false;
@@ -178,13 +246,15 @@ static int spi_tx_rx(HAL_SPI_Interface spi, uint8_t *tx_buf, uint8_t *rx_buf, ui
     return err_code ? 0 : size;
 }
 
-static void spi_transfer_cancel(HAL_SPI_Interface spi)
-{
-    nrfx_spim_abort(m_spi_map[spi].instance);
+static void spi_transfer_cancel(HAL_SPI_Interface spi) {
+    if (m_spi_map[spi].spi_mode == SPI_MODE_MASTER) {
+        nrfx_spim_abort(m_spi_map[spi].master);
+    } else {
+        // Not supported by SPI Slave
+    }
 }
 
-void HAL_SPI_Init(HAL_SPI_Interface spi)
-{
+void HAL_SPI_Init(HAL_SPI_Interface spi) {
     os_thread_scheduling(false, nullptr);
     if (m_spi_map[spi].mutex == nullptr) {
         os_mutex_recursive_create(&m_spi_map[spi].mutex);
@@ -193,8 +263,7 @@ void HAL_SPI_Init(HAL_SPI_Interface spi)
 
     HAL_SPI_Acquire(spi, nullptr);
 
-    if (m_spi_map[spi].enabled)
-    {
+    if (m_spi_map[spi].enabled) {
         spi_uninit(spi);
     }
 
@@ -205,210 +274,216 @@ void HAL_SPI_Init(HAL_SPI_Interface spi)
     m_spi_map[spi].bit_order = DEFAULT_BIT_ORDER;
     m_spi_map[spi].data_mode = DEFAULT_DATA_MODE;
     m_spi_map[spi].clock = DEFAULT_SPI_CLOCK;
-    m_spi_map[spi].user_callback = NULL;
+    m_spi_map[spi].spi_ss_state = 0;
+    m_spi_map[spi].spi_dma_user_callback = NULL;
+    m_spi_map[spi].spi_select_user_callback = NULL;
     m_spi_map[spi].transfer_length = 0;
 
     HAL_SPI_Release(spi, nullptr);
 }
 
-void HAL_SPI_Begin(HAL_SPI_Interface spi, uint16_t pin)
-{
+void HAL_SPI_Begin(HAL_SPI_Interface spi, uint16_t pin) {
     // Default to Master mode
     HAL_SPI_Begin_Ext(spi, SPI_MODE_MASTER, pin, NULL);
 }
 
-void HAL_SPI_Begin_Ext(HAL_SPI_Interface spi, SPI_Mode mode, uint16_t pin, void* reserved)
-{
-    if (m_spi_map[spi].ss_pin != NRFX_SPIM_PIN_NOT_USED)
-    {
+void HAL_SPI_Begin_Ext(HAL_SPI_Interface spi, SPI_Mode mode, uint16_t pin, void* reserved) {
+    if (m_spi_map[spi].ss_pin != PIN_INVALID) {
         ss_pin_uninit(spi);
     }
 
-    if (m_spi_map[spi].enabled)
-    {
+    if (m_spi_map[spi].enabled) {
         spi_uninit(spi);
     }
 
-    m_spi_map[spi].ss_pin = pin;
-
-    // TODO: need to support spi slave
+    m_spi_map[spi].ss_pin = (pin == SPI_DEFAULT_SS) ? PIN_INVALID : pin;
     m_spi_map[spi].spi_mode = mode;
-    spi_init(spi);
-
+    spi_init(spi, mode);
     m_spi_map[spi].enabled = true;
 }
 
-void HAL_SPI_End(HAL_SPI_Interface spi)
-{
+void HAL_SPI_End(HAL_SPI_Interface spi) {
     spi_uninit(spi);
     m_spi_map[spi].enabled = false;
 }
 
-void HAL_SPI_Set_Bit_Order(HAL_SPI_Interface spi, uint8_t order)
-{
+void HAL_SPI_Set_Bit_Order(HAL_SPI_Interface spi, uint8_t order) {
     m_spi_map[spi].bit_order = order;
-    if (m_spi_map[spi].enabled)
-    {
+    if (m_spi_map[spi].enabled) {
         spi_uninit(spi);
-        spi_init(spi);
+        spi_init(spi, m_spi_map[spi].spi_mode);
     }
 }
 
-void HAL_SPI_Set_Data_Mode(HAL_SPI_Interface spi, uint8_t mode)
-{
+void HAL_SPI_Set_Data_Mode(HAL_SPI_Interface spi, uint8_t mode) {
     m_spi_map[spi].data_mode = mode;
-    if (m_spi_map[spi].enabled)
-    {
+    if (m_spi_map[spi].enabled) {
         spi_uninit(spi);
-        spi_init(spi);
+        spi_init(spi, m_spi_map[spi].spi_mode);
     }
 }
 
-void HAL_SPI_Set_Clock_Divider(HAL_SPI_Interface spi, uint8_t rate)
-{
+void HAL_SPI_Set_Clock_Divider(HAL_SPI_Interface spi, uint8_t rate) {
     // actual speed is the system clock divided by some scalar
     m_spi_map[spi].clock = rate;
-    if (m_spi_map[spi].enabled)
-    {
+    if (m_spi_map[spi].enabled) {
         spi_uninit(spi);
-        spi_init(spi);
+        spi_init(spi, m_spi_map[spi].spi_mode);
     }
 }
 
-uint16_t HAL_SPI_Send_Receive_Data(HAL_SPI_Interface spi, uint16_t data)
-{
+uint16_t HAL_SPI_Send_Receive_Data(HAL_SPI_Interface spi, uint16_t data) {
+    if (m_spi_map[spi].spi_mode == SPI_MODE_SLAVE) {
+        return 0;
+    }
+
     uint8_t tx_buffer __attribute__((__aligned__(4)));
     uint8_t rx_buffer __attribute__((__aligned__(4)));
 
     // Wait for SPI transfer finished
-    while(m_spi_map[spi].transmitting);
+    while(m_spi_map[spi].transmitting) {
+        ;
+    }
 
     tx_buffer = data;
 
-    m_spi_map[spi].user_callback = NULL;
+    m_spi_map[spi].spi_dma_user_callback = NULL;
     spi_tx_rx(spi, &tx_buffer, &rx_buffer, 1);
 
     // Wait for SPI transfer finished
-    while(m_spi_map[spi].transmitting);
+    while(m_spi_map[spi].transmitting) {
+        ;
+    }
 
     return rx_buffer;
 }
 
-bool HAL_SPI_Is_Enabled(HAL_SPI_Interface spi)
-{
+bool HAL_SPI_Is_Enabled(HAL_SPI_Interface spi) {
     return m_spi_map[spi].enabled;
 }
 
-bool HAL_SPI_Is_Enabled_Old(void)
-{
+bool HAL_SPI_Is_Enabled_Old(void) {
     return false;
 }
 
-void HAL_SPI_DMA_Transfer(HAL_SPI_Interface spi, void* tx_buffer, void* rx_buffer, uint32_t length, HAL_SPI_DMA_UserCallback userCallback)
-{
-    while(m_spi_map[spi].transmitting);
-
-    m_spi_map[spi].user_callback = userCallback;
-    spi_tx_rx(spi, (uint8_t *)tx_buffer, (uint8_t *)rx_buffer, length);
-}
-
-void HAL_SPI_Info(HAL_SPI_Interface spi, hal_spi_info_t* info, void* reserved)
-{
+void HAL_SPI_Info(HAL_SPI_Interface spi, hal_spi_info_t* info, void* reserved) {
     info->system_clock = 64000000;
-    if (info->version >= HAL_SPI_INFO_VERSION_1)
-    {
+    if (info->version >= HAL_SPI_INFO_VERSION_1) {
         int32_t state = HAL_disable_irq();
-        if (m_spi_map[spi].enabled)
-        {
-            switch (m_spi_map[spi].clock)
-            {
-                case SPI_CLOCK_DIV2: info->clock = info->system_clock / 2; break;
-                case SPI_CLOCK_DIV4: info->clock = info->system_clock / 4; break;
-                case SPI_CLOCK_DIV8: info->clock = info->system_clock / 8; break;
-                case SPI_CLOCK_DIV16: info->clock = info->system_clock / 16; break;
-                case SPI_CLOCK_DIV32: info->clock = info->system_clock / 32; break;
-                case SPI_CLOCK_DIV64: info->clock = info->system_clock / 64; break;
+        if (m_spi_map[spi].enabled) {
+            switch (m_spi_map[spi].clock) {
+                case SPI_CLOCK_DIV2:   info->clock = info->system_clock / 2;   break;
+                case SPI_CLOCK_DIV4:   info->clock = info->system_clock / 4;   break;
+                case SPI_CLOCK_DIV8:   info->clock = info->system_clock / 8;   break;
+                case SPI_CLOCK_DIV16:  info->clock = info->system_clock / 16;  break;
+                case SPI_CLOCK_DIV32:  info->clock = info->system_clock / 32;  break;
+                case SPI_CLOCK_DIV64:  info->clock = info->system_clock / 64;  break;
                 case SPI_CLOCK_DIV128: info->clock = info->system_clock / 128; break;
                 case SPI_CLOCK_DIV256: info->clock = info->system_clock / 256; break;
                 default: info->clock = 0;
             }
-        }
-        else
-        {
+        } else {
             info->clock = 0;
         }
-        info->default_settings = ((m_spi_map[spi].spi_mode == DEFAULT_SPI_MODE) ||
+        info->default_settings = ((m_spi_map[spi].spi_mode  == DEFAULT_SPI_MODE) ||
                                   (m_spi_map[spi].bit_order == DEFAULT_BIT_ORDER) ||
                                   (m_spi_map[spi].data_mode == DEFAULT_DATA_MODE) ||
-                                  (m_spi_map[spi].clock == DEFAULT_SPI_CLOCK));
+                                  (m_spi_map[spi].clock     == DEFAULT_SPI_CLOCK));
         info->enabled = m_spi_map[spi].enabled;
         info->mode = m_spi_map[spi].spi_mode;
         info->bit_order = m_spi_map[spi].bit_order;
         info->data_mode = m_spi_map[spi].data_mode;
         if (info->version >= HAL_SPI_INFO_VERSION_2) {
-            info->ss_pin = m_spi_map[spi].ss_pin != NRFX_SPIM_PIN_NOT_USED ?
-                           NRF_PIN_LOOKUP_TABLE[m_spi_map[spi].ss_pin] : 0xffff;
+            info->ss_pin = m_spi_map[spi].ss_pin != PIN_INVALID ? NRF_PIN_LOOKUP_TABLE[m_spi_map[spi].ss_pin] : 0xffff;
         }
         HAL_enable_irq(state);
     }
 }
 
-void HAL_SPI_Set_Callback_On_Select(HAL_SPI_Interface spi, HAL_SPI_Select_UserCallback cb, void* reserved)
-{
-    // TODO: slave mode
+void HAL_SPI_Set_Callback_On_Select(HAL_SPI_Interface spi, HAL_SPI_Select_UserCallback cb, void* reserved) {
+    m_spi_map[spi].spi_select_user_callback = cb;
 }
 
-void HAL_SPI_DMA_Transfer_Cancel(HAL_SPI_Interface spi)
-{
-    spi_transfer_cancel(spi);
-    m_spi_map[spi].transmitting = false;
-    m_spi_map[spi].user_callback = NULL;
+void HAL_SPI_DMA_Transfer(HAL_SPI_Interface spi, void* tx_buffer, void* rx_buffer, uint32_t length, HAL_SPI_DMA_UserCallback userCallback) {
+    if (length == 0) {
+        return;
+    }
+
+    while(m_spi_map[spi].transmitting) {
+        ;
+    }
+
+    m_spi_map[spi].spi_dma_user_callback = userCallback;
+    if (m_spi_map[spi].spi_mode == SPI_MODE_MASTER) {
+        SPARK_ASSERT(spi_tx_rx(spi, (uint8_t *)tx_buffer, (uint8_t *)rx_buffer, length) == length);
+    } else {
+        // reset transfer length
+        m_spi_map[spi].transfer_length = 0;
+        HAL_SPI_Set_Slave_Buffers(spi, tx_buffer, rx_buffer, length);
+    }
 }
 
-int32_t HAL_SPI_DMA_Transfer_Status(HAL_SPI_Interface spi, HAL_SPI_TransferStatus* st)
-{
+void HAL_SPI_DMA_Transfer_Cancel(HAL_SPI_Interface spi) {
+    if (m_spi_map[spi].spi_mode == SPI_MODE_MASTER) {
+        spi_transfer_cancel(spi);
+        m_spi_map[spi].transmitting = false;
+        m_spi_map[spi].spi_dma_user_callback = NULL;
+    } else {
+        // Not supported by SPI Slave
+    }
+}
+
+int32_t HAL_SPI_DMA_Transfer_Status(HAL_SPI_Interface spi, HAL_SPI_TransferStatus* st) {
     int32_t transfer_length = 0;
 
-    if (m_spi_map[spi].transmitting)
-    {
+    if (m_spi_map[spi].transmitting) {
         transfer_length = 0;
-    }
-    else
-    {
+    } else {
         transfer_length = m_spi_map[spi].transfer_length;
     }
 
-    if (st != NULL)
-    {
+    if (st != NULL) {
         st->configured_transfer_length = m_spi_map[spi].transfer_length;
         st->transfer_length = (uint32_t)transfer_length;
         st->transfer_ongoing = m_spi_map[spi].transmitting;
-        // TODO: slave mode
-        // st->ss_state = spiState[spi].SPI_SS_State;
+        st->ss_state = m_spi_map[spi].spi_ss_state;
     }
 
     return transfer_length;
 }
 
-int32_t HAL_SPI_Set_Settings(HAL_SPI_Interface spi, uint8_t set_default, uint8_t clockdiv, uint8_t order, uint8_t mode, void* reserved)
-{
-    if (set_default)
-    {
+int32_t HAL_SPI_Set_Settings(HAL_SPI_Interface spi, uint8_t set_default, uint8_t clockdiv, uint8_t order, uint8_t mode, void* reserved) {
+    if (set_default) {
         m_spi_map[spi].data_mode = DEFAULT_DATA_MODE;
         m_spi_map[spi].bit_order = DEFAULT_BIT_ORDER;
         m_spi_map[spi].clock = DEFAULT_SPI_CLOCK;
-    }
-    else
-    {
+    } else {
         m_spi_map[spi].data_mode = mode;
         m_spi_map[spi].bit_order = order;
         m_spi_map[spi].clock = clockdiv;
     }
 
-    if (m_spi_map[spi].enabled)
-    {
+    if (m_spi_map[spi].enabled) {
         spi_uninit(spi);
-        spi_init(spi);
+        spi_init(spi, m_spi_map[spi].spi_mode);
+    }
+
+    return 0;
+}
+
+int32_t HAL_SPI_Set_Slave_Buffers(HAL_SPI_Interface spi, void* tx_buffer, void* rx_buffer, uint32_t length) {
+    m_spi_map[spi].slave_buf_length = length;
+    m_spi_map[spi].slave_tx_buf = tx_buffer;
+    m_spi_map[spi].slave_rx_buf = rx_buffer;
+    uint32_t err_code = nrfx_spis_buffers_set(m_spi_map[spi].slave, 
+                                        (uint8_t *)m_spi_map[spi].slave_tx_buf, 
+                                        m_spi_map[spi].slave_buf_length, 
+                                        (uint8_t *)m_spi_map[spi].slave_rx_buf, 
+                                        m_spi_map[spi].slave_buf_length);
+    if (err_code == NRF_ERROR_INVALID_STATE) {
+        // LOG_DEBUG(WARN, "nrfx_spis_buffers_set, invalid state");
+    } else {
+        SPARK_ASSERT(err_code == NRF_SUCCESS);
     }
 
     return 0;

--- a/platform/MCU/nRF52840/inc/sdk_config_system.h
+++ b/platform/MCU/nRF52840/inc/sdk_config_system.h
@@ -98,8 +98,11 @@
 #define NRFX_TWIM1_ENABLED      1
 
 #define NRFX_SPIM_ENABLED       1
+#define NRFX_SPIS_ENABLED       1
 #define NRFX_SPIM2_ENABLED      1
 #define NRFX_SPIM3_ENABLED      1
+#define NRFX_SPIS2_ENABLED      1
+#define NRFX_SPIS3_ENABLED      1
 
 #define NRFX_TIMER2_ENABLED     1
 

--- a/user/tests/wiring/spi_master_slave/spi_slave/spi_slave.cpp
+++ b/user/tests/wiring/spi_master_slave/spi_slave/spi_slave.cpp
@@ -119,9 +119,11 @@ test(SPI_Master_Slave_Slave_Transfer)
         /* Preload SLAVE_TEST_MESSAGE_1 reply */
         memcpy(SPI_Slave_Tx_Buffer, SLAVE_TEST_MESSAGE_1, sizeof(SLAVE_TEST_MESSAGE_1));
 
-        /* Wait for Master to select us */
-        while(SPI_Selected_State == 0);
-        SPI_Selected_State = 0;
+        /* IMPORTANT: NOT waiting for Master to select us, as some of the platforms
+         * require TX and RX buffers to be configured before CS goes low
+         */
+        // while(SPI_Selected_State == 0);
+        // SPI_Selected_State = 0;
 
         /* Receive up to TRANSFER_LENGTH_2 bytes */
         SPI_Transfer_DMA(SPI_Slave_Tx_Buffer, SPI_Slave_Rx_Buffer, TRANSFER_LENGTH_2, count % 2 == 0 ? &SPI_DMA_Completed_Callback : NULL);


### PR DESCRIPTION

### Problem

Implement SPI Slave

### Steps to Test

1. Change `TEST_MASTER_APP` to `1`, flash the application to Xenon-SPI-Master device
2. Change `TEST_MASTER_APP` to `0`, flash the application to Xenon-SPI-Slave device
3. Connect serial dongle to TX pin on Xenon to observe the log, SPI master will send and receive data from 1 byte to 10 bytes.

### TODOs
1. D2 D3 D4 are assigned to SPI1, but they are used by ethernet wing, we could change these pins to A0, A1, A2
2. SPI3 doesn’t support SPI slave mode and only SPI3 supports up to 32MHz clock
3. This SPI driver **CANNOT** pass `wiring` test. On STM32 we can set slave buffer after CS pin is pulled low. But on nRF52, we have to set SPI slave buffer before the transition started.
https://devzone.nordicsemi.com/f/nordic-q-a/39387/spis-set-buffer

### Example App

```c
#include "application.h"

SYSTEM_MODE(MANUAL);
Serial1LogHandler   logHandler(115200, LOG_LEVEL_ALL);

#define CS_PIN              A5

#define TEST_MASTER_APP     1

#if TEST_MASTER_APP
volatile uint8_t tx_buffer[100] = {'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I'};
volatile uint8_t rx_buffer[100] = {0};
volatile static uint32_t transfer_state = 0x00;

void onTransferFinished() {
    transfer_state = 1;
    // Log.printf(">> trans done!\r\n");
}

/* executes once at startup */
void setup() {

}

/* executes continuously after setup() runs */
void loop() {
    static int tx_counter = 0;
    SPI1.begin(SPI_MODE_MASTER, CS_PIN);
    SPI1.setDataMode(SPI_MODE3);
    Log.printf("\r\n");
    digitalWrite(CS_PIN, 0);
    transfer_state = 0;
    SPI1.transfer((void *)tx_buffer, (void *)rx_buffer, tx_counter++ % 10 + 1, onTransferFinished);
    while(transfer_state == 0) {
        ;
    }
    digitalWrite(CS_PIN, 1);
    SPI1.end();
    Log.printf("master read: %s\r\n", rx_buffer);
    if (SPI1.available() > 0) {
        Log.printf("Received %d bytes ", SPI1.available());
        for (int i = 0; i < SPI1.available(); i++) {
            Log.printf("%02x ", rx_buffer[i]);
        }
        Log.printf("\r\n");
    }
    memset((void *)rx_buffer, 0, 100);
    
    delay(1000);
}

#else

volatile uint8_t tx_buffer[100] = {'1', '2', '3', '4', '5', '6', '7', '8', '9'};
volatile uint8_t rx_buffer[100] = {0};
static volatile uint32_t select_state = 0x00;
static volatile uint32_t transfer_state = 0x00;

void onTransferFinished() {
    transfer_state = 1;
    Log.printf(">> trans done!\r\n");
}

void onSelect(uint8_t state) {
    if (state) {
        select_state = state;
    }

    Log.printf(">> cs pin: %d!\r\n", state);
}

/* executes once at startup */
void setup() {
    SPI1.onSelect(onSelect);
    SPI1.begin(SPI_MODE_SLAVE, CS_PIN);

    // TODO: add a function to set tx rx buffer for SPI slave
    SPI1.transfer((void *)tx_buffer, (void *)rx_buffer, sizeof(rx_buffer), onTransferFinished);
}

/* executes continuously after setup() runs */
void loop() {
    while (1) {
        delay(1000);
        if (SPI1.available() > 0) {
            Log.printf("Received %d bytes ", SPI1.available());
            for (int i = 0; i < SPI1.available(); i++) {
                Log.printf("%02x ", rx_buffer[i]);
            }
            Log.printf("\r\n");
            memset((void *)rx_buffer, 0, 100);
        }
    }
}
#endif
```

### References

[CH19818]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
