### PR TITLE
[Mesh] mbedtls: adds hardware accelerated sha1

### DIFF
--- a/hal/src/nRF52840/mbedtls/mbedtls_config_platform.h
+++ b/hal/src/nRF52840/mbedtls/mbedtls_config_platform.h
@@ -230,6 +230,7 @@
 #define MBEDTLS_AES_ALT
 #define MBEDTLS_ECP_ALT
 #define MBEDTLS_SHA256_ALT
+#define MBEDTLS_SHA1_ALT
 
 //#define MBEDTLS_ARC4_ALT
 //#define MBEDTLS_BLOWFISH_ALT
@@ -240,7 +241,6 @@
 //#define MBEDTLS_MD4_ALT
 //#define MBEDTLS_MD5_ALT
 //#define MBEDTLS_RIPEMD160_ALT
-//#define MBEDTLS_SHA1_ALT
 //#define MBEDTLS_SHA512_ALT
 
 /**

--- a/hal/src/nRF52840/mbedtls/sha1_alt.h
+++ b/hal/src/nRF52840/mbedtls/sha1_alt.h
@@ -1,0 +1,158 @@
+/*
+ *  sha1_alt.h
+ *
+ *  Copyright (C) 2018, Arm Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+#ifndef MBEDTLS_SHA1_ALT_H
+#define MBEDTLS_SHA1_ALT_H
+
+#if !defined(MBEDTLS_CONFIG_FILE)
+#include "config.h"
+#else
+#include MBEDTLS_CONFIG_FILE
+#endif
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef MBEDTLS_SHA1_ALT
+
+#include "crys_hash.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * \brief          SHA-1 context structure
+ */
+typedef struct
+{
+    CRYS_HASHUserContext_t crys_hash_ctx;
+} mbedtls_sha1_context;
+
+/**
+ * \brief          This function initializes a SHA-1 context.
+ *
+ * \param ctx      The SHA-1 context to initialize.
+ *
+ * \warning        SHA-1 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
+ */
+void mbedtls_sha1_init( mbedtls_sha1_context *ctx );
+
+/**
+ * \brief          This function clears a SHA-1 context.
+ *
+ * \param ctx      The SHA-1 context to clear.
+ *
+ * \warning        SHA-1 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
+ */
+void mbedtls_sha1_free( mbedtls_sha1_context *ctx );
+
+/**
+ * \brief          This function clones the state of a SHA-1 context.
+ *
+ * \param dst      The destination context.
+ * \param src      The context to clone.
+ *
+ * \warning        SHA-1 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
+ */
+void mbedtls_sha1_clone( mbedtls_sha1_context *dst,
+                         const mbedtls_sha1_context *src );
+
+/**
+ * \brief          This function starts a SHA-1 checksum calculation.
+ *
+ * \param ctx      The context to initialize.
+ *
+ * \return         \c 0 if successful
+ *
+ * \warning        SHA-1 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
+ */
+int mbedtls_sha1_starts_ret( mbedtls_sha1_context *ctx );
+
+/**
+ * \brief          This function feeds an input buffer into an ongoing SHA-1
+ *                 checksum calculation.
+ *
+ * \param ctx      The SHA-1 context.
+ * \param input    The buffer holding the input data.
+ * \param ilen     The length of the input data.
+ *
+ * \return         \c 0 if successful
+ *
+ * \warning        SHA-1 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
+ */
+int mbedtls_sha1_update_ret( mbedtls_sha1_context *ctx,
+                             const unsigned char *input,
+                             size_t ilen );
+
+/**
+ * \brief          This function finishes the SHA-1 operation, and writes
+ *                 the result to the output buffer.
+ *
+ * \param ctx      The SHA-1 context.
+ * \param output   The SHA-1 checksum result.
+ *
+ * \return         \c 0 if successful
+ *
+ * \warning        SHA-1 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
+ */
+int mbedtls_sha1_finish_ret( mbedtls_sha1_context *ctx,
+                             unsigned char output[20] );
+
+/**
+ * \brief          SHA-1 process data block (internal use only)
+ *
+ * \param ctx      SHA-1 context
+ * \param data     The data block being processed.
+ *
+ * \return         \c 0 if successful
+ *
+ * \warning        SHA-1 is considered a weak message digest and its use
+ *                 constitutes a security risk. We recommend considering
+ *                 stronger message digests instead.
+ *
+ */
+int mbedtls_internal_sha1_process( mbedtls_sha1_context *ctx,
+                                   const unsigned char data[64] );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // MBEDTLS_SHA1_ALT
+#endif // MBEDTLS_SHA1_ALT_H

--- a/hal/src/nRF52840/mbedtls/sha1_alt_cc310.c
+++ b/hal/src/nRF52840/mbedtls/sha1_alt_cc310.c
@@ -1,0 +1,82 @@
+/*
+ *  sha1_alt.c
+ *
+ *  Copyright (C) 2018, Arm Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+#include "mbedtls/sha1.h"
+#if defined(MBEDTLS_SHA1_ALT)
+#include <string.h>
+
+#include "cc310_mbedtls.h"
+
+void mbedtls_sha1_init( mbedtls_sha1_context *ctx )
+{
+    memset( ctx, 0, sizeof( mbedtls_sha1_context ) );
+
+}
+
+void mbedtls_sha1_free( mbedtls_sha1_context *ctx )
+{
+    if( ctx == NULL )
+        return;
+
+    CC310_OPERATION_NO_RESULT( CRYS_HASH_Free( &ctx->crys_hash_ctx ) );
+
+    memset( ctx, 0, sizeof( mbedtls_sha1_context ) );
+}
+
+void mbedtls_sha1_clone( mbedtls_sha1_context *dst,
+                         const mbedtls_sha1_context *src )
+{
+    memcpy( dst, src, sizeof( mbedtls_sha1_context ) );
+}
+
+int mbedtls_sha1_starts_ret( mbedtls_sha1_context *ctx )
+{
+    int ret = 0;
+    CC310_OPERATION( CRYS_HASH_Init( &ctx->crys_hash_ctx, CRYS_HASH_SHA1_mode ), ret );
+    return ret;
+}
+
+
+int mbedtls_sha1_update_ret( mbedtls_sha1_context *ctx,
+                             const unsigned char *input,
+                             size_t ilen )
+{
+    int ret = 0;
+    CC310_OPERATION( CRYS_HASH_Update( &ctx->crys_hash_ctx, (uint8_t*)input, ilen ), ret );
+    return ret;
+}
+
+int mbedtls_sha1_finish_ret( mbedtls_sha1_context *ctx,
+                             unsigned char output[20] )
+{
+    CRYS_HASH_Result_t crys_result = {0};
+    int ret = 0;
+    CC310_OPERATION( CRYS_HASH_Finish( &ctx->crys_hash_ctx, crys_result ), ret);
+    memcpy( output, crys_result, CRYS_HASH_SHA1_DIGEST_SIZE_IN_BYTES );
+    return ret;
+}
+
+int mbedtls_internal_sha1_process( mbedtls_sha1_context *ctx,
+                                   const unsigned char data[64] )
+{
+    return mbedtls_sha1_update_ret( ctx, data, 64 );
+}
+
+#endif // MBEDTLS_SHA1_ALT


### PR DESCRIPTION
### Description

This PR adds hardware-accelerated alternative version of mbedtls SHA1 functions relying on CC310 peripheral available on NRF52840 devices.

### Steps to Test

N/A

### Example App

N/A

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
