### PR TITLE
[nrf52840] constructor array should start at an aligned location

### DIFF
--- a/modules/shared/nRF52840/part1.ld
+++ b/modules/shared/nRF52840/part1.ld
@@ -64,6 +64,8 @@ SECTIONS
         *(.glue_7)
         *(.glue_7t)
 
+        . = ALIGN(4);
+
         link_constructors_location = .;
         chk_system_pre_init_start = .;
         KEEP (*(.module_pre_init))


### PR DESCRIPTION
### Problem

system-part1 C++ constructor array may end up at an unaligned address.

### Solution

Enforce alignment in system-part1 linker file.

### Steps to Test

N/A

### Example App

N/A

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
