### PR TITLE
[Mesh] Adds DHCP hostname for Ethernet and WiFi interfaces

### DIFF
--- a/hal/network/lwip/esp32/esp32ncpnetif.cpp
+++ b/hal/network/lwip/esp32/esp32ncpnetif.cpp
@@ -39,6 +39,8 @@ LOG_SOURCE_CATEGORY("net.esp32ncp")
 #include "lwiplock.h"
 #include "wifi_ncp_client.h"
 #include "concurrent_hal.h"
+#include "deviceid_hal.h"
+#include "bytes2hexbuf.h"
 
 #include "platform_config.h"
 
@@ -105,6 +107,15 @@ err_t Esp32NcpNetif::initInterface() {
     /* FIXME: Remove once we enable IPv6 */
     netif_.flags |= NETIF_FLAG_NO_ND6;
     /* netif_.flags |= NETIF_FLAG_MLD6 */
+
+    uint8_t deviceId[HAL_DEVICE_ID_SIZE] = {};
+    uint8_t deviceIdLen = HAL_device_ID(deviceId, sizeof(deviceId));
+    hostname_ = std::make_unique<char[]>(deviceIdLen * 2 + 1);
+    if (hostname_) {
+        bytes2hexbuf_lower_case(deviceId, deviceIdLen, hostname_.get());
+        hostname_[deviceIdLen * 2] = '\0';
+    }
+    netif_set_hostname(interface(), hostname_.get());
 
     netif_.output = etharp_output;
     netif_.output_ip6 = ethip6_output;

--- a/hal/network/lwip/esp32/esp32ncpnetif.h
+++ b/hal/network/lwip/esp32/esp32ncpnetif.h
@@ -25,6 +25,7 @@
 #include <lwip/pbuf.h>
 #include "wifi_network_manager.h"
 #include "ncp_client.h"
+#include <memory>
 
 #ifdef __cplusplus
 
@@ -71,6 +72,7 @@ private:
     std::atomic_bool exit_;
     bool up_ = false;
     particle::WifiNetworkManager* wifiMan_ = nullptr;
+    std::unique_ptr<char[]> hostname_;
 };
 
 } } // namespace particle::net

--- a/hal/network/lwip/ifapi.cpp
+++ b/hal/network/lwip/ifapi.cpp
@@ -665,7 +665,7 @@ int if_set_xflags(if_t iface, unsigned int xflags) {
         return -1;
     }
 
-    if (flags & IFF_POINTTOPOINT) {
+    if ((flags & IFF_POINTTOPOINT) || !(flags & IFF_BROADCAST)) {
         /* Drop DHCPv4 flag */
         xflags &= ~(IFXF_DHCP);
     }

--- a/hal/network/lwip/wiznet/wiznetif.h
+++ b/hal/network/lwip/wiznet/wiznetif.h
@@ -25,6 +25,7 @@
 #include <atomic>
 #include <lwip/netif.h>
 #include <lwip/pbuf.h>
+#include <memory>
 
 #ifdef __cplusplus
 
@@ -89,6 +90,8 @@ private:
 
     /* FIXME: Wiznet callbacks do not have any kind of state arguments :( */
     static WizNetif* instance_;
+
+    std::unique_ptr<char[]> hostname_;
 };
 
 } } // namespace particle::net

--- a/hal/src/nRF52840/lwip/lwipopts.h
+++ b/hal/src/nRF52840/lwip/lwipopts.h
@@ -1046,7 +1046,7 @@ void sys_unlock_tcpip_core(void);
  * LWIP_NETIF_HOSTNAME==1: use DHCP_OPTION_HOSTNAME with netif's hostname
  * field.
  */
-#define LWIP_NETIF_HOSTNAME             0
+#define LWIP_NETIF_HOSTNAME             1
 
 /**
  * LWIP_NETIF_API==1: Support netif api (in netifapi.c)


### PR DESCRIPTION
### Description

- Sets default hostname to deviceId on Ethernet and WiFi interfaces
- Enables LwIP `LWIP_NETIF_HOSTNAME` option

### Steps to Test

N/A

### Example App

N/A

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
