### PR TITLE
[Mesh] Fixes a conflict between DHCPv4 and ND6 DNS server list

### DIFF
--- a/hal/src/nRF52840/lwip/lwipopts.h
+++ b/hal/src/nRF52840/lwip/lwipopts.h
@@ -441,11 +441,6 @@ void sys_unlock_tcpip_core(void);
 #define LWIP_IPV4_SRC_ROUTING           1
 
 /**
- * LWIP_L3_BRIDGE==1: Enables the ability to L3 bridge IP/IPv6 interfaces
- */
-#define LWIP_L3_BRIDGE                  1
-
-/**
  * IP_REASSEMBLY==1: Reassemble incoming fragmented IP packets. Note that
  * this option does not affect outgoing packet sizes, which can be controlled
  * via IP_FRAG.
@@ -575,7 +570,7 @@ void sys_unlock_tcpip_core(void);
  * netif drivers might not set this flag, the default is off. If enabled,
  * netif_set_link_up() must be called to continue dhcp starting.
  */
-#define LWIP_DHCP_CHECK_LINK_UP         0
+#define LWIP_DHCP_CHECK_LINK_UP         1
 
 /**
  * LWIP_DHCP_BOOTP_FILE==1: Store offered_si_addr and boot_file_name.


### PR DESCRIPTION
### Problem

Despite the fact that we currently don't support IPv6 on non-mesh interfaces, our network stack still processes incoming ND6 (RFC4861) messages. When receiving RA, ND6 code will blindly overwrite DNS servers previously set by DHCPv4.

### Solution

Disable ND6 packet processing if `NETIF_FLAG_NO_ND6` is set on the interface (particle-iot/lwip#3). This holds true at the moment for all our interfaces.

### Steps to Test

Check that Argons or Xenons with Ethernet FeatherWing can correctly perform gateway functionality when connected to an IPv6-enabled network on WiFi or Ethernet interface.

### Example App

N/A

### References

- [CH24688]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
