### PR TITLE
_CONST was dropped in Newlib 3.0.0

### DIFF
--- a/services/inc/printf_export.h
+++ b/services/inc/printf_export.h
@@ -51,12 +51,12 @@ _printf_float (struct _reent *data,
            struct _prt_data_t *pdata,
            FILE *fp,
            int (*pfunc)(struct _reent *, FILE *,
-                _CONST char *, size_t len),
+                const char *, size_t len),
            va_list *ap);
 
 int
 _printf_i (struct _reent *data, struct _prt_data_t *pdata, FILE *fp,
-     int (*pfunc)(struct _reent *, FILE *, _CONST char *, size_t len),
+     int (*pfunc)(struct _reent *, FILE *, const char *, size_t len),
      va_list *ap);
 
 int _svfprintf_r(struct _reent *, FILE *, const char *, va_list) _ATTRIBUTE ((__format__ (__printf__, 3, 0)));


### PR DESCRIPTION
### Problem

If eventually the firmware is built with Newlib 3.0.0, then without this change there's an `error: unknown type name '_CONST'` because `_CONST` was [dropped in Newlib 3.0.0](https://sourceware.org/git/gitweb.cgi?p=newlib-cygwin.git;a=commit;h=0bda30e1ffd23488aa4a9b73f228089463fbee1a).

### Solution

This patch follows the same pattern as the change in Newlib and replaces `_CONST` with `const`. Building with previous version of Newlib is unaffected. The firmware already employs the `const` type qualifier.

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)