### PR TITLE
[NCP] Unblock parser when the muxer exits asynchronously and fixes a race condition in muxer

### DIFF
--- a/hal/src/argon/network/esp32_ncp_client.cpp
+++ b/hal/src/argon/network/esp32_ncp_client.cpp
@@ -584,6 +584,8 @@ int Esp32NcpClient::muxChannelStateCb(uint8_t channel, decltype(muxer_)::Channel
         switch (channel) {
             case 0:
                 // Muxer stopped
+                self->disable();
+                // NOTE: fall-through
             case ESP32_NCP_STA_CHANNEL: {
                 // Notify that the underlying data channel closed
                 // It should be safe to call this here

--- a/hal/src/boron/network/sara_ncp_client.cpp
+++ b/hal/src/boron/network/sara_ncp_client.cpp
@@ -899,6 +899,7 @@ int SaraNcpClient::muxChannelStateCb(uint8_t channel, decltype(muxer_)::ChannelS
         switch (channel) {
             case 0: {
                 // Muxer stopped
+                self->disable();
                 self->connState_ = NcpConnectionState::DISCONNECTED;
                 break;
             }


### PR DESCRIPTION
### Description

- https://github.com/particle-iot/gsm0710muxer/pull/2
- When the muxer stops asynchronously for example due to a keepalive timeout or due to the other peer requesting to terminate the link, we should unblock the parser as well.

### Steps to Test

N/A

### Example App

N/A

### References

- [CH25380]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
