### PR TITLE
[Gen 3] Some LwIP optimizations

### DIFF
--- a/hal/network/lwip/ppp_client.cpp
+++ b/hal/network/lwip/ppp_client.cpp
@@ -16,6 +16,9 @@
  */
 
 #include "ppp_client.h"
+
+#if defined(PPP_SUPPORT) && PPP_SUPPORT
+
 #include "service_debug.h"
 extern "C" {
 #include <netif/ppp/pppos.h>
@@ -434,3 +437,5 @@ void Client::transition(State newState) {
     }
   }
 }
+
+#endif // defined(PPP_SUPPORT) && PPP_SUPPORT

--- a/hal/network/lwip/ppp_client.h
+++ b/hal/network/lwip/ppp_client.h
@@ -24,6 +24,9 @@
 extern "C" {
 #include <netif/ppp/ppp.h>
 }
+
+#if defined(PPP_SUPPORT) && PPP_SUPPORT
+
 #include "ppp_ipcp.h"
 #include "concurrent_hal.h"
 #include <mutex>
@@ -173,5 +176,7 @@ private:
 } } } /* namespace particle::net::ppp */
 
 #endif /* __cplusplus */
+
+#endif // defined(PPP_SUPPORT) && PPP_SUPPORT
 
 #endif /* HAL_NETWORK_LWIP_PPP_CLIENT_H */

--- a/hal/network/lwip/ppp_ipcp.cpp
+++ b/hal/network/lwip/ppp_ipcp.cpp
@@ -16,6 +16,9 @@
  */
 
 #include "ppp_ipcp.h"
+
+#if defined(PPP_SUPPORT) && PPP_SUPPORT
+
 #include <lwip/dns.h>
 #include "logging.h"
 
@@ -493,3 +496,5 @@ ip4_addr_t Ipcp::getNegotiatedSecondaryDns() {
   }
   return ret;
 }
+
+#endif // defined(PPP_SUPPORT) && PPP_SUPPORT

--- a/hal/network/lwip/ppp_ipcp.h
+++ b/hal/network/lwip/ppp_ipcp.h
@@ -19,6 +19,9 @@
 #define HAL_NETWORK_LWIP_PPP_IPCP_H
 
 #include "ppp_ncp.h"
+
+#if defined(PPP_SUPPORT) && PPP_SUPPORT
+
 #include <netif/ppp/ipcp.h>
 #include "ppp_ipcp_options.h"
 
@@ -129,5 +132,7 @@ private:
 } } } /* namespace particle::net::ppp */
 
 #endif /* __cplusplus */
+
+#endif // defined(PPP_SUPPORT) && PPP_SUPPORT
 
 #endif /* HAL_NETWORK_LWIP_PPP_IPCP_H */

--- a/hal/network/lwip/ppp_ncp.cpp
+++ b/hal/network/lwip/ppp_ncp.cpp
@@ -16,5 +16,3 @@
  */
 
 #include "ppp_ncp.h"
-
-using namespace particle::net::ppp;

--- a/hal/network/lwip/ppp_ncp.h
+++ b/hal/network/lwip/ppp_ncp.h
@@ -30,6 +30,8 @@ extern "C" {
 #include <netif/ppp/fsm.h>
 }
 
+#if defined(PPP_SUPPORT) && PPP_SUPPORT
+
 #include "ppp_configuration_option.h"
 
 #ifdef __cplusplus
@@ -425,5 +427,7 @@ fsm_callbacks Ncp<protocol, ContextVariable, protoName, dataProtoName>::fsmCallb
 } } } /* namespace particle::net::ppp */
 
 #endif /* __cplusplus */
+
+#endif // defined(PPP_SUPPORT) && PPP_SUPPORT
 
 #endif /* HAL_NETWORK_LIP_PPP_NCP_H */

--- a/hal/src/nRF52840/lwip/lwipopts.h
+++ b/hal/src/nRF52840/lwip/lwipopts.h
@@ -344,7 +344,7 @@ void sys_unlock_tcpip_core(void);
 /**
  * PBUF_POOL_SIZE: the number of buffers in the pbuf pool.
  */
-#define PBUF_POOL_SIZE                  24
+#define PBUF_POOL_SIZE                  16
 
 /*
    ---------------------------------

--- a/hal/src/nRF52840/lwip/lwippppopts.h
+++ b/hal/src/nRF52840/lwip/lwippppopts.h
@@ -18,10 +18,13 @@
 #ifndef HAL_LWIP_LWIPPPPOPTS_H
 #define HAL_LWIP_LWIPPPPOPTS_H
 
+#include "platforms.h"
+
 /**
  * PPP_SUPPORT==1: Enable PPP.
  */
-#define PPP_SUPPORT                     1
+// TODO: There should probably be separate config files for each Gen 3 platform
+#define PPP_SUPPORT                     (PLATFORM_ID == PLATFORM_BORON)
 
 /**
  * PPPOE_SUPPORT==1: Enable PPP Over Ethernet
@@ -52,7 +55,7 @@
  * MEMP_NUM_PPP_PCB: the number of simultaneously active PPP
  * connections (requires the PPP_SUPPORT option)
  */
-#define MEMP_NUM_PPP_PCB                2
+#define MEMP_NUM_PPP_PCB                1
 
 /**
  * PPP_NUM_TIMEOUTS_PER_PCB: the number of sys_timeouts running in parallel per

--- a/wiring/inc/spark_wiring_posix_common.h
+++ b/wiring/inc/spark_wiring_posix_common.h
@@ -67,7 +67,8 @@ inline void ipAddressPortToSockaddr(const IPAddress& addr, uint16_t port, struct
         inaddr->sin_family = AF_INET;
         inaddr->sin_port = htons(port);
         const auto& a = addr.raw();
-        inaddr->sin_addr.s_addr = a.ipv4;
+        // NOTE: HAL_IPAddress.ipv4 is host-order :|
+        inaddr->sin_addr.s_addr = htonl(a.ipv4);
     }
 #endif // HAL_IPv6
 }


### PR DESCRIPTION
### Solution

1. `PBUF_POOL_SIZE` reduced to 16
2. PPP completely disabled on Argon and Xenon
3. Also fixes an endianness issue with `IPAddress` -> `sockaddr_in` conversion

### Steps to test

N/A

### Example App

N/A

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
