### PR TITLE
[boron] cellular_hal: fixes a crash with STARTUP() macros and credentials management functions

### DIFF
--- a/hal/src/boron/cellular_hal.cpp
+++ b/hal/src/boron/cellular_hal.cpp
@@ -142,12 +142,10 @@ int cellular_device_info(CellularDevice* info, void* reserved) {
 }
 
 int cellular_credentials_set(const char* apn, const char* user, const char* password, void* reserved) {
-    const auto mgr = cellularNetworkManager();
-    CHECK_TRUE(mgr, SYSTEM_ERROR_UNKNOWN);
     auto sim = particle::SimType::INTERNAL;
-    CHECK(mgr->getActiveSim(&sim));
+    CHECK(CellularNetworkManager::getActiveSim(&sim));
     auto cred = CellularNetworkConfig().apn(apn).user(user).password(password);
-    CHECK(mgr->setNetworkConfig(sim, std::move(cred)));
+    CHECK(CellularNetworkManager::setNetworkConfig(sim, std::move(cred)));
     return 0;
 }
 
@@ -155,13 +153,9 @@ CellularCredentials* cellular_credentials_get(void* reserved) {
     // TODO: Copy the settings to a storage provided by the calling code
     static CellularCredentials cred;
     static CellularNetworkConfig conf;
-    const auto mgr = cellularNetworkManager();
-    if (!mgr) {
-        return nullptr;
-    }
     auto sim = particle::SimType::INTERNAL;
-    CHECK_RETURN(mgr->getActiveSim(&sim), nullptr);
-    CHECK_RETURN(mgr->getNetworkConfig(sim, &conf), nullptr);
+    CHECK_RETURN(CellularNetworkManager::getActiveSim(&sim), nullptr);
+    CHECK_RETURN(CellularNetworkManager::getNetworkConfig(sim, &conf), nullptr);
     cred.apn = conf.hasApn() ? conf.apn() : "";
     cred.username = conf.hasUser() ? conf.user() : "";
     cred.password = conf.hasPassword() ? conf.password() : "";
@@ -169,11 +163,9 @@ CellularCredentials* cellular_credentials_get(void* reserved) {
 }
 
 int cellular_credentials_clear(void* reserved) {
-    const auto mgr = cellularNetworkManager();
-    CHECK_TRUE(mgr, SYSTEM_ERROR_UNKNOWN);
     auto sim = particle::SimType::INTERNAL;
-    CHECK(mgr->getActiveSim(&sim));
-    CHECK(mgr->clearNetworkConfig(sim));
+    CHECK(CellularNetworkManager::getActiveSim(&sim));
+    CHECK(CellularNetworkManager::clearNetworkConfig(sim));
     return 0;
 }
 
@@ -352,21 +344,17 @@ int cellular_band_available_get(MDM_BandSelect* bands, void* reserved) {
 }
 
 int cellular_set_active_sim(int simType, void* reserved) {
-    const auto mgr = cellularNetworkManager();
-    CHECK_TRUE(mgr, SYSTEM_ERROR_UNKNOWN);
     auto sim = particle::SimType::INTERNAL;
     if (simType == EXTERNAL_SIM) {
         sim = particle::SimType::EXTERNAL;
     }
-    CHECK(mgr->setActiveSim(sim));
+    CHECK(CellularNetworkManager::setActiveSim(sim));
     return 0;
 }
 
 int cellular_get_active_sim(int* simType, void* reserved) {
-    const auto mgr = cellularNetworkManager();
-    CHECK_TRUE(mgr, SYSTEM_ERROR_UNKNOWN);
     auto sim = particle::SimType::INTERNAL;
-    CHECK(mgr->getActiveSim(&sim));
+    CHECK(CellularNetworkManager::getActiveSim(&sim));
     if (sim == particle::SimType::EXTERNAL) {
         *simType = EXTERNAL_SIM;
     } else {


### PR DESCRIPTION
### Problem

The following code will cause a crash on Boron:
```
STARTUP(Cellular.setActiveSim(EXTERNAL_SIM));
STARTUP(Cellular.setCredentials("spark.telefonica.com", "", ""));
```

The issue stems from the fact that user-part C++ constructors are executed very early before the whole networking subsystem is properly initialized.

### Solution

Use static member functions of `CellularNetworkManager` in `cellular_hal` instead of obtaining (and as a consequence constructing) its instance in functions managing credentials.

### Steps to Test

Run the example app. It shouldn't crash.

### Example App

```cpp
STARTUP(Cellular.setActiveSim(EXTERNAL_SIM));
STARTUP(Cellular.setCredentials("spark.telefonica.com", "", ""));

void setup() {
}

void loop() {
}
```

### References

- [CH25566]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
