### PR TITLE
Fixes user part update procedure in hybrid build

### DIFF
--- a/hal/src/nRF52840/core_hal.c
+++ b/hal/src/nRF52840/core_hal.c
@@ -293,7 +293,7 @@ void HAL_Core_Config(void) {
     HAL_RNG_Configuration();
 
     HAL_RTC_Configuration();
-    
+
 #if defined(MODULAR_FIRMWARE)
     if (HAL_Core_Validate_User_Module()) {
         new_heap_end = module_user_pre_init();
@@ -305,8 +305,8 @@ void HAL_Core_Config(void) {
         // Set the heap end to the stack start to make most use of the SRAM.
         malloc_set_heap_end(&_Stack_Init);
 
-        // Try copying the embedded user image to user application address
-        user_update();
+        // Update the user module if needed
+        user_update_if_needed();
     }
 
     // Enable malloc before littlefs initialization.

--- a/hal/src/nRF52840/user.cpp
+++ b/hal/src/nRF52840/user.cpp
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2018 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
 
 #include <stdint.h>
 #include "core_hal.h"
@@ -6,27 +22,46 @@
 #include "module_info.h"
 #include "user_hal.h"
 #include "ota_flash_hal_impl.h"
-
+#include "system_error.h"
 
 #define USER_ADDR (module_user.start_address)
 
 
 #if defined(INCLUDE_APP)
-int user_update(void)
+
+static bool user_module_present_and_valid()
 {
-    uint32_t user_image_size = 0;
-    const uint8_t* user_image = HAL_User_Image(&user_image_size, nullptr);
+    return FLASH_isUserModuleInfoValid(FLASH_INTERNAL, USER_FIRMWARE_IMAGE_LOCATION,
+            USER_FIRMWARE_IMAGE_LOCATION) &&
+            FLASH_VerifyCRC32(FLASH_INTERNAL, USER_FIRMWARE_IMAGE_LOCATION,
+                FLASH_ModuleLength(FLASH_INTERNAL, USER_FIRMWARE_IMAGE_LOCATION));
+}
 
-    int updated = FLASH_CopyMemory(FLASH_INTERNAL, (uint32_t)user_image,
-                                   FLASH_INTERNAL, USER_ADDR, user_image_size, MODULE_FUNCTION_USER_PART,
-                                   MODULE_VERIFY_DESTINATION_IS_START_ADDRESS|MODULE_VERIFY_CRC|MODULE_VERIFY_FUNCTION);
+int user_update_if_needed(void)
+{
+    int updated = SYSTEM_ERROR_INVALID_STATE;
 
+    // Update only if there is no user part at all or it doesn't pass integrity validation
+    if (!user_module_present_and_valid()) {
+        uint32_t user_image_size = 0;
+        const uint8_t* user_image = HAL_User_Image(&user_image_size, nullptr);
+
+        updated = FLASH_CopyMemory(FLASH_INTERNAL, (uint32_t)user_image,
+                FLASH_INTERNAL, USER_ADDR, user_image_size, MODULE_FUNCTION_USER_PART,
+                MODULE_VERIFY_DESTINATION_IS_START_ADDRESS|MODULE_VERIFY_CRC|MODULE_VERIFY_FUNCTION);
+        if (updated == FLASH_ACCESS_RESULT_OK) {
+            updated = SYSTEM_ERROR_NONE;
+        } else {
+            updated = SYSTEM_ERROR_UNKNOWN;
+        }
+    }
     return updated;
 }
+
 #else
-int user_update(void)
+
+int user_update_if_needed(void)
 {
-    return FLASH_ACCESS_RESULT_ERROR;
+    return SYSTEM_ERROR_NOT_SUPPORTED;
 }
 #endif // INCLUDE_APP
-

--- a/hal/src/nRF52840/user.h
+++ b/hal/src/nRF52840/user.h
@@ -1,23 +1,22 @@
-/**
-   Copyright (c) 2013-2016 Particle Industries, Inc.  All rights reserved.
-
-   This library is free software; you can redistribute it and/or
-   modify it under the terms of the GNU Lesser General Public
-   License as published by the Free Software Foundation, either
-   version 3 of the License, or (at your option) any later version.
-
-   This library is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-   Lesser General Public License for more details.
-
-   You should have received a copy of the GNU Lesser General Public
-   License along with this library; if not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************
+/*
+ * Copyright (c) 2018 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
  */
 
 #ifndef USER_H
-#define	USER_H
+#define USER_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -25,12 +24,10 @@ extern "C" {
 
 #include <stdint.h>
 
-int user_update(void);
-
+int user_update_if_needed(void);
 
 #ifdef __cplusplus
 }
 #endif
 
 #endif	/* USER_H */
-

--- a/system/src/system_task.cpp
+++ b/system/src/system_task.cpp
@@ -387,7 +387,13 @@ void handle_cloud_connection(bool force_events)
                 CloudDiagnostics::instance()->status(CloudDiagnostics::CONNECTED);
                 system_notify_event(cloud_status, cloud_status_connected);
                 if (system_mode() == SAFE_MODE) {
-                    LED_SIGNAL_START(SAFE_MODE, BACKGROUND); // Connected to the cloud while in safe mode
+/* FIXME: there should be macro that checks for NetworkManager availability */
+                    // Connected to the cloud while in safe mode
+#if !HAL_PLATFORM_IFAPI
+                    LED_SIGNAL_START(SAFE_MODE, BACKGROUND);
+#else
+                    LED_SIGNAL_START(SAFE_MODE, NORMAL);
+#endif /* !HAL_PLATFORM_IFAPI */
                 } else {
 /* FIXME: there should be macro that checks for NetworkManager availability */
 #if !HAL_PLATFORM_IFAPI


### PR DESCRIPTION
### Problem

When flashing a user-part that depends on the newer version of system-part1, hybrid firmware will overwrite that user part with the embedded tinker due to failed dependency check (https://github.com/particle-iot/firmware/blob/mesh-develop/hal/src/nRF52840/core_hal.c#L352), preventing safe mode from triggering and as a consequence preventing safe mode healer from applying newer system-part1 to resolve the dependencies.

### Solution

Flash the embedded tinker only if there is no valid user module or it fails to pass the integrity check. Dependencies shouldn't be checked.

This PR also fixes safe mode LED indication priority issue.

### Steps to Test

1. Build with `HYBRID_BUILD=y INCLUDE_APP=y`
2. Flash `system-part1`
3. Erase user-part
4. Reset
5. The device should boot into tinker
6. Bump module versions, rebuild normal modular firmware + some different app
7. Flash user-part OTA
8. The device should accept the new user firmware, reset and go into safe mode
9. Flash bumped system-part1 OTA
10. The device should accept the new system-part1, reset and go into normal breathing cyan running the app that was flashed at step 8.

### Example App

N/A

### References

- [CH25698]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
