### PR TITLE
Fixes an assertion failure in LwIP DHCP code when receiving an offer with > 2 DNS servers

### DIFF
--- a/hal/src/nRF52840/lwip/lwipopts.h
+++ b/hal/src/nRF52840/lwip/lwipopts.h
@@ -28,6 +28,10 @@
 
 #include "lwip_logging.h"
 
+#ifndef DEBUG_BUILD
+#define LWIP_NOASSERT
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */

--- a/hal/src/nRF52840/lwip/sys_arch.c
+++ b/hal/src/nRF52840/lwip/sys_arch.c
@@ -228,6 +228,9 @@ sys_mutex_lock(sys_mutex_t *mutex)
 
   ret = xSemaphoreTakeRecursive(mutex->mut, portMAX_DELAY);
   LWIP_ASSERT("failed to take the mutex", ret == pdTRUE);
+#ifdef LWIP_NOASSERT
+  LWIP_UNUSED_ARG(ret);
+#endif // LWIP_NOASSERT
 }
 
 void
@@ -239,6 +242,9 @@ sys_mutex_unlock(sys_mutex_t *mutex)
 
   ret = xSemaphoreGiveRecursive(mutex->mut);
   LWIP_ASSERT("failed to give the mutex", ret == pdTRUE);
+#ifdef LWIP_NOASSERT
+  LWIP_UNUSED_ARG(ret);
+#endif // LWIP_NOASSERT
 }
 
 void
@@ -271,7 +277,12 @@ sys_sem_new(sys_sem_t *sem, u8_t initial_count)
   if(initial_count == 1) {
     BaseType_t ret = xSemaphoreGive(sem->sem);
     LWIP_ASSERT("sys_sem_new: initial give failed", ret == pdTRUE);
+
+#ifdef LWIP_NOASSERT
+    LWIP_UNUSED_ARG(ret);
+#endif // LWIP_NOASSERT
   }
+
   return ERR_OK;
 }
 
@@ -286,6 +297,10 @@ sys_sem_signal(sys_sem_t *sem)
   /* queue full is OK, this is a signal only... */
   LWIP_ASSERT("sys_sem_signal: sane return value",
     (ret == pdTRUE) || (ret == errQUEUE_FULL));
+
+#ifdef LWIP_NOASSERT
+  LWIP_UNUSED_ARG(ret);
+#endif // LWIP_NOASSERT
 }
 
 u32_t
@@ -350,6 +365,10 @@ sys_mbox_post(sys_mbox_t *mbox, void *msg)
 
   ret = xQueueSendToBack(mbox->mbx, &msg, portMAX_DELAY);
   LWIP_ASSERT("mbox post failed", ret == pdTRUE);
+
+#ifdef LWIP_NOASSERT
+  LWIP_UNUSED_ARG(ret);
+#endif // LWIP_NOASSERT
 }
 
 err_t
@@ -491,6 +510,11 @@ sys_thread_new(const char *name, lwip_thread_fn thread, void *arg, int stacksize
   LWIP_ASSERT("task creation failed", ret == pdTRUE);
 
   lwip_thread.thread_handle = rtos_task;
+
+#ifdef LWIP_NOASSERT
+  LWIP_UNUSED_ARG(ret);
+#endif // LWIP_NOASSERT
+
   return lwip_thread;
 }
 
@@ -612,6 +636,11 @@ sys_check_core_locking(void)
 #else /* LWIP_TCPIP_CORE_LOCKING */
     LWIP_ASSERT("Function called from wrong thread", current_thread == lwip_tcpip_thread);
 #endif /* LWIP_TCPIP_CORE_LOCKING */
+
+#ifdef LWIP_NOASSERT
+  LWIP_UNUSED_ARG(current_thread);
+#endif // LWIP_NOASSERT
+
   }
 #endif /* !NO_SYS */
 }

--- a/third_party/lwip/build.mk
+++ b/third_party/lwip/build.mk
@@ -5,6 +5,9 @@ include $(TARGET_LWIP_SRC_PATH)/Filelists.mk
 
 CSRC += $(LWIPNOAPPSFILES)
 
+# FIXME: we'd rather not have this enabled and instead fix the issue in LwIP code
+CFLAGS += -Wno-unused-variable
+
 ifeq ("$(PLATFORM_LWIP)","posix")
 CSRC += $(LWIP_MODULE_PATH)/lwip-contrib/ports/unix/port/netif/tapif.c
 endif


### PR DESCRIPTION
### Problem

Xenons with Ethernet FeatherWing and Argons go into panic state due to an assertion failure in LwIP DHCP code when receiving a DHCP OFFER with more than 2 DNS servers.

### Solution

1. Fix the bug in LwIP code: https://github.com/particle-iot/lwip/pull/4
2. Disables LwIP assertions in non-debug builds

### Steps to Test

Configure DHCP server to provide more than 2 DNS servers. The devices should successfully lease an IP address without going into panic.

### Example App

N/A

### References

- https://github.com/particle-iot/lwip/pull/4
- [CH25692]
- [CH25694]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
