### PR TITLE
Do not log WiFi passwords

### DIFF
--- a/hal/network/ncp/at_parser/at_parser.cpp
+++ b/hal/network/ncp/at_parser/at_parser.cpp
@@ -127,6 +127,12 @@ void AtParser::echoEnabled(bool enabled) {
     }
 }
 
+void AtParser::logEnabled(bool enabled) {
+    if (p_) {
+        p_->logEnabled(enabled);
+    }
+}
+
 AtParserConfig AtParser::config() const {
     if (!p_) {
         return AtParserConfig();

--- a/hal/network/ncp/at_parser/at_parser.h
+++ b/hal/network/ncp/at_parser/at_parser.h
@@ -71,6 +71,12 @@ public:
      * @see `echoEnabled()`
      */
     static const auto DEFAULT_ECHO_ENABLED = true;
+    /**
+     * Default state of the logging.
+     *
+     * @see `logEnabled()`
+     */
+    static const auto DEFAULT_LOG_ENABLED = true;
 
     /**
      * Constructs a settings object with all parameters set to their default values.
@@ -156,6 +162,20 @@ public:
      * @see `DEFAULT_ECHO_ENABLED`
      */
     bool echoEnabled() const;
+    /**
+     * Enables or disables the logging of AT commands.
+     *
+     * @return This settings object.
+     *
+     * @see `DEFAULT_LOG_ENABLED`
+     */
+    AtParserConfig& logEnabled(bool enabled);
+    /**
+     * Returns `true` if the logging of AT commands is enabled, or `false` otherwise.
+     *
+     * @see `DEFAULT_LOG_ENABLED`
+     */
+    bool logEnabled() const;
 
 private:
     Stream* strm_;
@@ -163,6 +183,7 @@ private:
     unsigned cmdTimeout_;
     unsigned strmTimeout_;
     bool echoEnabled_;
+    bool logEnabled_;
 };
 
 /**
@@ -341,6 +362,13 @@ public:
      */
     void echoEnabled(bool enabled);
     /**
+     * Enables or disables the logging of AT commands.
+     *
+     * @see `config()`
+     * @see `AtParserConfig::logEnabled()`
+     */
+    void logEnabled(bool enabled);
+    /**
      * Returns the parser settings.
      *
      * @return Settings object.
@@ -360,7 +388,8 @@ inline AtParserConfig::AtParserConfig() :
         cmdTerm_(DEFAULT_COMMAND_TERMINATOR),
         cmdTimeout_(DEFAULT_COMMAND_TIMEOUT),
         strmTimeout_(DEFAULT_STREAM_TIMEOUT),
-        echoEnabled_(DEFAULT_ECHO_ENABLED) {
+        echoEnabled_(DEFAULT_ECHO_ENABLED),
+        logEnabled_(DEFAULT_LOG_ENABLED) {
 }
 
 inline AtParserConfig& AtParserConfig::stream(Stream* strm) {
@@ -406,6 +435,15 @@ inline AtParserConfig& AtParserConfig::echoEnabled(bool enabled) {
 
 inline bool AtParserConfig::echoEnabled() const {
     return echoEnabled_;
+}
+
+inline AtParserConfig& AtParserConfig::logEnabled(bool enabled) {
+    logEnabled_ = enabled;
+    return *this;
+}
+
+inline bool AtParserConfig::logEnabled() const {
+    return logEnabled_;
 }
 
 } // particle

--- a/hal/network/ncp/at_parser/at_parser_impl.h
+++ b/hal/network/ncp/at_parser/at_parser_impl.h
@@ -72,6 +72,7 @@ public:
     void reset();
 
     void echoEnabled(bool enabled);
+    void logEnabled(bool enabled);
     const AtParserConfig& config() const;
 
     static bool isConfigValid(const AtParserConfig& conf);
@@ -163,6 +164,10 @@ inline bool AtParserImpl::atLineEnd() const {
 
 inline void AtParserImpl::echoEnabled(bool enabled) {
     conf_.echoEnabled(enabled);
+}
+
+inline void AtParserImpl::logEnabled(bool enabled) {
+    conf_.logEnabled(enabled);
 }
 
 inline const AtParserConfig& AtParserImpl::config() const {


### PR DESCRIPTION
### Problem

The AT command parser logs all AT commands and responses, including WiFi passwords on the Argon platform. Given that we often request device logs from the users this may disclose their sensitive data.

### Solution

- Update the parser to make it possible to disable logging for certain commands.
- Disable logging of the echo received from the NCP.

### Steps to Test

Compile and flash the firmware and make sure the WiFi password doesn't get logged during the network connection.

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
