### PR TITLE
[nrf52840] Enables power failure comparator on boot with a registered power failure handler that resets the device

### DIFF
--- a/platform/MCU/nRF52840/inc/sdk_config_bootloader.h
+++ b/platform/MCU/nRF52840/inc/sdk_config_bootloader.h
@@ -22,6 +22,10 @@
 // modules/nrfx/templates/nRF52840/nrfx_config.h
 // config/nrf52840/config/sdk_config.h
 
+// IMPORTANT: these two should be set to the same value
+#define NRFX_CLOCK_CONFIG_IRQ_PRIORITY 0
+#define NRFX_POWER_CONFIG_IRQ_PRIORITY 0
+
 #define NRFX_GPIOTE_ENABLED 0
 
 #define NRFX_RTC_ENABLED 0

--- a/platform/MCU/nRF52840/inc/sdk_config_system.h
+++ b/platform/MCU/nRF52840/inc/sdk_config_system.h
@@ -24,6 +24,10 @@
 // modules/nrfx/templates/nRF52840/nrfx_config.h
 // config/nrf52840/config/sdk_config.h
 
+// IMPORTANT: these two should be set to the same value
+#define NRFX_CLOCK_CONFIG_IRQ_PRIORITY 0
+#define NRFX_POWER_CONFIG_IRQ_PRIORITY 0
+
 #define NRFX_GPIOTE_ENABLED                             1
 #define GPIOTE_CONFIG_IRQ_PRIORITY                      APP_IRQ_PRIORITY_HIGH
 #define NRFX_GPIOTE_CONFIG_NUM_OF_LOW_POWER_EVENTS      8


### PR DESCRIPTION
### Problem

nRF52840 MCU can easily operate at voltage as low as 1.7V, however the external QSPI flash we are using requires at least 2.8V, thus we require some form of undervoltage protection, because several key components of the DeviceOS rely on the external flash: DCT, OpenThread settings, WiFi settings.

### Solution

We've previously introduced a workaround in the bootloader: we've enabled nRF52840 power failure comparator configured for 2.8V in early boot for about 200ms, checked if a failure was detected and reset the device if so.

This PR enables the power failure comparator in early boot as well, but keeps it running with a registered handler function which will reset the device if power failure is detected at any point in time while the device runs.

### Steps to Test

Use lab power supply and gradually decrease voltage to about 2.8V, the device should reset and fail to boot. Increase the voltage above 2.8V, the device should boot and function normally.

### Example App

N/A

### References

- [CH25867]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
