### PR TITLE
Do not set the sticky skip hello after handshake

### DIFF
--- a/communication/src/protocol.cpp
+++ b/communication/src/protocol.cpp
@@ -335,7 +335,6 @@ int Protocol::begin()
 	}
 	LOG(INFO,"Handshake completed");
 	channel.notify_established();
-	flags |= SKIP_SESSION_RESUME_HELLO;
 	return error;
 }
 


### PR DESCRIPTION
### Problem

After OTA the device should send the HELLO message so it gets prompted to send its describe message.

Occasionally after sending the HELLO message, the cloud communications fail. After reconnecting, it does not send the HELLO message again so the version of firmware running on the device is not updated in the database.

### Solution

The correct logic is in `DTLSMessageChannel`, but this sticky flag that gets set before we hear anything back from the cloud in fact breaks it in case the cloud disconnects before the describe message is sent since the HELLO won't be sent after reconnecting.

### Steps to Test

* `$ particle flash tinker-serial1-debugging-0.8.0-rc.25-xenon.bin  --usb`
* Pull power
* Verify in the database that current_build_target is 0.8.0-rc.25
* `$ particle flash x2 system-part1-0.8.0-rc.26-xenon.bin`
* Expect in the database that current_build_target is 0.8.0-rc.26

### Completeness

- [x] User is totes amazing for contributing!
- [X] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
