### PR TITLE
Fixes Network Manager initial state after network_setup()

### DIFF
--- a/system/src/system_network_manager_api.cpp
+++ b/system/src/system_network_manager_api.cpp
@@ -107,6 +107,8 @@ const CellularConfig* cellularConfig() {
 void network_setup(network_handle_t network, uint32_t flags, void* reserved) {
     system_set_flag(SYSTEM_FLAG_RESET_NETWORK_ON_CLOUD_ERRORS, 0, nullptr);
     NetworkManager::instance()->init();
+    // Populate the list
+    NetworkManager::instance()->disableInterface();
 }
 
 const void* network_config(network_handle_t network, uint32_t param, void* reserved) {


### PR DESCRIPTION
### Problem

Interface state list in Network Manager is not populated until `network_connect()` call is made.

### Solution

Populate it in `network_setup()`.

### Steps to Test

N/A

### Example App

N/A

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
