### PR TITLE
[LTE] AT+CNUM command causing registration failure on LTE devices

### DIFF
--- a/hal/src/electron/modem/mdm_hal.cpp
+++ b/hal/src/electron/modem/mdm_hal.cpp
@@ -1034,17 +1034,14 @@ bool MDMParser::checkNetStatus(NetStatus* status /*= NULL*/)
     if (REG_OK(_net.csd) || REG_OK(_net.psd) || REG_OK(_net.eps))
     {
         sendFormated("AT+COPS?\r\n");
-        if (RESP_OK != waitFinalResp(_cbCOPS, &_net))
+        if (RESP_OK != waitFinalResp(_cbCOPS, &_net)) {
             goto failure;
-        // get the MSISDNs related to this subscriber
-        sendFormated("AT+CNUM\r\n");
-        if (RESP_OK != waitFinalResp(_cbCNUM, _net.num))
-            goto failure;
-
+        }
         // get the signal strength indication
         sendFormated("AT+CSQ\r\n");
-        if (RESP_OK != waitFinalResp(_cbCSQ, &_net))
+        if (RESP_OK != waitFinalResp(_cbCSQ, &_net)) {
             goto failure;
+        }
     }
     if (status) {
         memcpy(status, &_net, sizeof(NetStatus));


### PR DESCRIPTION
### Problem

AT+CNUM command is used in the registration process just to log the phone number of the inserted SIM.  It has been observed that some SIMs in LTE devices have invalid characters in the phone number string that causes this command to error.  
```
40.796 AT send       9 "AT+CNUM\r\n"
40.826 AT read ERR  49 "\r\n+CME ERROR: invalid characters in dial string\r\n"
```
This prevents the registration process from completing and the device will blink green continuously.

### Solution

Remove the AT+CNUM command.

### Steps to Test

Test on a unit that was previously causing this error.  It should now connect without a problem.

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] (N/A) documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
