### PR TITLE
[Photon] Memory usage optimizations

### DIFF
--- a/hal/src/photon/miniz.h
+++ b/hal/src/photon/miniz.h
@@ -859,7 +859,8 @@ enum
     TINFL_MAX_HUFF_SYMBOLS_0 = 288,
     TINFL_MAX_HUFF_SYMBOLS_1 = 32,
     TINFL_MAX_HUFF_SYMBOLS_2 = 19,
-    TINFL_FAST_LOOKUP_BITS = 10,
+    /* The value of this field has been changed from 10 to 5 to reduce the size of the tinfl_decompressor structure */
+    TINFL_FAST_LOOKUP_BITS = 5,
     TINFL_FAST_LOOKUP_SIZE = 1 << TINFL_FAST_LOOKUP_BITS
 };
 


### PR DESCRIPTION
### Problem

The decompression of the WiFi blob firmware, which is performed every time `WiFi.on()` is called, requires about 10K of heap memory in 0.8.0-rc.11, and such an increased memory usage can pose a problem for user applications.

### Solution

- Tweak miniz to reduce the size of the decompressor context structure (`tinfl_decompressor`). The fix in this PR reduces the size of the structure from 10 to 5K at the cost of some performance hit. I would appreciate double-checking if the proposed change is safe.
- ~Do not reset the network interface on cloud connection errors on the Photon. The previous behavior can be enabled by setting [`SYSTEM_FLAG_RESET_NETWORK_ON_CLOUD_ERRORS`](https://prerelease-docs.particle.io/reference/firmware/photon/#system-flags-disable-) in a user application.~

### Steps to Test

Flash the following application to a Photon and verify that the amount of free memory doesn't drop below 45K during network connection attempts:

```cpp
#include "application.h"

SYSTEM_MODE(SEMI_AUTOMATIC)
SYSTEM_THREAD(ENABLED)

namespace {

const Serial1LogHandler logHandler(115200, LOG_LEVEL_WARN, {
    { "app", LOG_LEVEL_ALL }
});

system_tick_t lastMillis = 0;
bool wifiOn = false;

} // namespace

void setup() {
    Log.info("setup(): %u", (unsigned)System.freeMemory());
    lastMillis = millis();
}

void loop() {
    if (millis() - lastMillis >= 100) {
        Log.info("loop(): %u", (unsigned)System.freeMemory());
        lastMillis = millis();
    }
    if (millis() > 3000 && !wifiOn) {
        Log.info("WiFi.on()");
        WiFi.on();
        wifiOn = true;
    }
}
```

### References

- https://github.com/particle-iot/firmware/issues/748
- [ch25791]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation ([Required update](https://prerelease-docs.particle.io/reference/firmware/photon/#system-flags-disable-))
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)