### PR TITLE
[nrf52840] hal: implements __assert_func() to handle libc assert()

### DIFF
--- a/hal/src/nRF52840/newlib.cpp
+++ b/hal/src/nRF52840/newlib.cpp
@@ -1,5 +1,7 @@
 #include "service_debug.h"
 #include <stdlib.h>
+#include <assert.h>
+#include "delay_hal.h"
 
 /**
  * Shared newlib implementation for stm32 devices. (This is probably suitable for all embedded devices on gcc.)
@@ -57,6 +59,11 @@ void _exit(int status) {
     }
 }
 
+void __assert_func(const char *file, int line, const char* func, const char* expr) {
+    LOG(ERROR, "Assertion failed: %s:%d %s (%s)", file, line, func, expr);
+    PANIC(AssertionFailure, expr);
+    while(1);
+}
 
 int _write(int file, char *ptr, int len) { return 0; }
 int _read(int file, char *ptr, int len) { return 0; }

--- a/rt-dynalib/inc/rt_dynalib.h
+++ b/rt-dynalib/inc/rt_dynalib.h
@@ -26,6 +26,7 @@
 
 #ifdef DYNALIB_EXPORT
 #include <errno.h>
+#include <assert.h>
 #endif
 
 DYNALIB_BEGIN(rt)
@@ -46,5 +47,6 @@ DYNALIB_FN(12, rt, _malloc_r, void*(struct _reent*, size_t))
 DYNALIB_FN(13, rt, _free_r, void(struct _reent*, void*))
 DYNALIB_FN(14, rt, _realloc_r, void*(struct _reent*, void*, size_t))
 DYNALIB_FN(15, rt, __errno, int*())
+DYNALIB_FN(16, rt, __assert_func, void(const char*, int, const char*, const char*))
 
 DYNALIB_END(rt)


### PR DESCRIPTION
### Problem

Currentl libc `assert()` will simply trigger `abort()` and `_exit()`, which doesn't really give us any insight into the cause of the failure.

### Solution

This PR implements newlib `__assert_func()` that logs the assertion failure information and executes the correct panic handler.

### Steps to Test

Run the test app, open device's serial port, log output should contain assertion failure info.

### Example App

```cpp

SerialLogHandler dbg(LOG_LEVEL_ALL);

void setup() {
}

void loop() {
    if (Serial.isConnected()) {
        assert(false);
    }
}
```

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
