### PR TITLE
Fixes to the Argon in Listening Mode showing wrong MAC address with the command `m`.

### DIFF
--- a/hal/network/lwip/esp32/esp32ncpnetif.cpp
+++ b/hal/network/lwip/esp32/esp32ncpnetif.cpp
@@ -147,9 +147,7 @@ int Esp32NcpNetif::queryMacAddress() {
 void Esp32NcpNetif::loop(void* arg) {
     Esp32NcpNetif* self = static_cast<Esp32NcpNetif*>(arg);
     unsigned int timeout = 100;
-    auto r = self->queryMacAddress();
-    if (r) // Failed to query MAC Address
-        return;
+    self->queryMacAddress();
     self->wifiMan_->ncpClient()->off();
     while(!self->exit_) {
         self->wifiMan_->ncpClient()->enable(); // Make sure the client is enabled

--- a/hal/network/lwip/esp32/esp32ncpnetif.cpp
+++ b/hal/network/lwip/esp32/esp32ncpnetif.cpp
@@ -124,9 +124,32 @@ err_t Esp32NcpNetif::initInterface() {
     return ERR_OK;
 }
 
+int Esp32NcpNetif::queryMacAddress() {
+    auto r = wifiMan_->ncpClient()->on();
+    if (r) {
+        LOG(TRACE, "Failed to initialize ESP32 NCP client: %d", r);
+        return r;
+    }
+    MacAddress mac = {};
+    if (!memcmp(interface()->hwaddr, mac.data, interface()->hwaddr_len)) {
+        // Query MAC address
+        r = wifiMan_->ncpClient()->getMacAddress(&mac);
+        if (r) {
+            LOG(TRACE, "Failed to query ESP32 MAC address: %d", r);
+            return r;
+        }
+        memcpy(interface()->hwaddr, mac.data, interface()->hwaddr_len);
+    }
+
+    return r;
+}
+
 void Esp32NcpNetif::loop(void* arg) {
     Esp32NcpNetif* self = static_cast<Esp32NcpNetif*>(arg);
     unsigned int timeout = 100;
+    auto r = self->queryMacAddress();
+    if (r) // Failed to query MAC Address
+        return;
     self->wifiMan_->ncpClient()->off();
     while(!self->exit_) {
         self->wifiMan_->ncpClient()->enable(); // Make sure the client is enabled
@@ -202,21 +225,9 @@ int Esp32NcpNetif::powerDown() {
 
 int Esp32NcpNetif::upImpl() {
     up_ = true;
-    auto r = wifiMan_->ncpClient()->on();
-    if (r) {
-        LOG(TRACE, "Failed to initialize ESP32 NCP client: %d", r);
+    auto r = queryMacAddress();
+    if (r) // Failed to query MAC address
         return r;
-    }
-    MacAddress mac = {};
-    if (!memcmp(interface()->hwaddr, mac.data, interface()->hwaddr_len)) {
-        // Query MAC address
-        r = wifiMan_->ncpClient()->getMacAddress(&mac);
-        if (r) {
-            LOG(TRACE, "Failed to query ESP32 MAC address: %d", r);
-            return r;
-        }
-        memcpy(interface()->hwaddr, mac.data, interface()->hwaddr_len);
-    }
     // Ensure that we are disconnected
     downImpl();
     // Restore up flag

--- a/hal/network/lwip/esp32/esp32ncpnetif.h
+++ b/hal/network/lwip/esp32/esp32ncpnetif.h
@@ -60,6 +60,8 @@ private:
     static err_t initCb(netif *netif);
     err_t initInterface();
 
+    int queryMacAddress();
+    
     static void loop(void* arg);
 
     /* LwIP netif linkoutput callback */

--- a/hal/src/argon/wlan_hal.cpp
+++ b/hal/src/argon/wlan_hal.cpp
@@ -192,12 +192,12 @@ int wlan_fetch_ipconfig(WLanConfig* conf) {
     CHECK_TRUE(iface, SYSTEM_ERROR_INVALID_STATE);
     unsigned flags = 0;
     CHECK(if_get_flags(iface, &flags));
-    CHECK_TRUE((flags & IFF_UP) && (flags & IFF_LOWER_UP), SYSTEM_ERROR_INVALID_STATE);
     // MAC address
     sockaddr_ll hwAddr = {};
     CHECK(if_get_lladdr(iface, &hwAddr));
     CHECK_TRUE((size_t)hwAddr.sll_halen == MAC_ADDRESS_SIZE, SYSTEM_ERROR_UNKNOWN);
     memcpy(conf->nw.uaMacAddr, hwAddr.sll_addr, MAC_ADDRESS_SIZE);
+    CHECK_TRUE((flags & IFF_UP) && (flags & IFF_LOWER_UP), SYSTEM_ERROR_INVALID_STATE);
     // IP address
     if_addrs* ifAddrList = nullptr;
     CHECK(if_get_addrs(iface, &ifAddrList));

--- a/system/src/system_setup.cpp
+++ b/system/src/system_setup.cpp
@@ -317,17 +317,16 @@ template<typename Config> void SystemSetupConsole<Config>::handle(char c)
     else if ('m' == c)
     {
         print("Your device MAC address is\r\n");
-    #if !HAL_PLATFORM_WIFI    
         IPConfig config = {};
+    #if !HAL_PLATFORM_WIFI    
         auto conf = static_cast<const IPConfig*>(network_config(0, 0, 0));
+    #else
+        auto conf = static_cast<const IPConfig*>(network_config(NETWORK_INTERFACE_WIFI_STA, 0, 0));
+    #endif
         if (conf && conf->size) {
             memcpy(&config, conf, conf->size);
         }
-        const uint8_t* addr = config.nw.uaMacAddr;
-    #else
-        auto conf = static_cast<const IPConfig*>(network_config(NETWORK_INTERFACE_WIFI_STA, 0, 0));
         const uint8_t* addr = conf->nw.uaMacAddr;
-    #endif
         print(bytes2hex(addr++, 1).c_str());
         for (int i = 1; i < 6; i++)
         {

--- a/system/src/system_setup.cpp
+++ b/system/src/system_setup.cpp
@@ -317,12 +317,17 @@ template<typename Config> void SystemSetupConsole<Config>::handle(char c)
     else if ('m' == c)
     {
         print("Your device MAC address is\r\n");
+    #if !HAL_PLATFORM_WIFI    
         IPConfig config = {};
         auto conf = static_cast<const IPConfig*>(network_config(0, 0, 0));
         if (conf && conf->size) {
             memcpy(&config, conf, conf->size);
         }
         const uint8_t* addr = config.nw.uaMacAddr;
+    #else
+        auto conf = static_cast<const IPConfig*>(network_config(NETWORK_INTERFACE_WIFI_STA, 0, 0));
+        const uint8_t* addr = conf->nw.uaMacAddr;
+    #endif
         print(bytes2hex(addr++, 1).c_str());
         for (int i = 1; i < 6; i++)
         {

--- a/system/src/system_setup.cpp
+++ b/system/src/system_setup.cpp
@@ -324,9 +324,9 @@ template<typename Config> void SystemSetupConsole<Config>::handle(char c)
         auto conf = static_cast<const IPConfig*>(network_config(NETWORK_INTERFACE_WIFI_STA, 0, 0));
     #endif
         if (conf && conf->size) {
-            memcpy(&config, conf, conf->size);
+            memcpy(&config, conf, std::min(sizeof(config), (size_t)conf->size));
         }
-        const uint8_t* addr = conf->nw.uaMacAddr;
+        const uint8_t* addr = config.nw.uaMacAddr;
         print(bytes2hex(addr++, 1).c_str());
         for (int i = 1; i < 6; i++)
         {


### PR DESCRIPTION
### Problem

The Argon shows MAC address with "00:00:00:00:00:00" in Listening Mode with command `m` which is incorrect.

### Solution

Allows to read MAC address from NCP even the interface is not up yet.

### Steps to Test

1. Compile and load system-part1 using DFU to an Argon.
2. Enter Listening Mode and press `m`, it should show the Wi-Fi MAC address correctly.
3. Using `$ particle serial mac` should also show it correctly.

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
