### PR TITLE
[argon] ncp: updateFirmware() after the NCP reset needs to re-enable the client

### DIFF
--- a/hal/src/argon/network/esp32_ncp_client.cpp
+++ b/hal/src/argon/network/esp32_ncp_client.cpp
@@ -285,6 +285,13 @@ int Esp32NcpClient::updateFirmware(InputStream* file, size_t size) {
         LOG(ERROR, "Unexpected result code: \"%s\"", buf);
         return SYSTEM_ERROR_UNKNOWN;
     }
+    // Stop the muxer
+    muxer_.stop();
+    // Wait a bit for the NCP to reset
+    HAL_Delay_Milliseconds(2000);
+    // Re-enable the client in case it was asynchronously disabled by the muxer
+    // due to the NCP reset
+    enable();
     // FIXME: Find a better way to reset the client state
     off();
     CHECK(on());


### PR DESCRIPTION
### Problem

Fixes a regression introduced by #1608: `updateFirmware()` always returns `SYSTEM_ERROR_INVALID_STATE` despite applying the update successfully.

### Solution

Manually stop the muxer after applying the update, wait for the NCP to reset, re-enable the client and reset client state.

### Steps to Test

```console
$ particle flash --serial argon-ncp-firmware-0.0.5-ota.bin
```

The device log should contain the following line right before resetting:
```console
0000087159 [hal] INFO: ESP32 firmware version updated to version 5
```

### Example App

```cpp
SYSTEM_MODE(MANUAL);

Serial1LogHandler dbg(115200, LOG_LEVEL_ALL);

void setup() {
    Network.listen(true);
}

void loop() {
}
```

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
