### PR TITLE
Fix SYSTEM_04_button_mirror test

### DIFF
--- a/user/tests/wiring/no_fixture/system.cpp
+++ b/user/tests/wiring/no_fixture/system.cpp
@@ -85,13 +85,6 @@ static void onButtonClick(system_event_t ev, int data) {
 
 test(SYSTEM_04_button_mirror)
 {
-    // Known bug:
-    // events posted from an ISR might not be delivered to the application queue
-    // when threading is enabled
-    if (system_thread_get_state(nullptr) == spark::feature::ENABLED) {
-        skip();
-        return;
-    }
     System.buttonMirror(D1, FALLING, false);
     auto pinmap = HAL_Pin_Map();
     System.on(button_click, onButtonClick);
@@ -119,7 +112,12 @@ test(SYSTEM_04_button_mirror)
     EXTI_GenerateSWInterrupt(pinmap[D1].gpio_pin);
     delay(300);
     pinMode(D1, INPUT_PULLUP);
-    delay(300);
+
+    // Make sure all asynchronous events get processed by the application thread
+    const auto t = millis();
+    do {
+        Particle.process();
+    } while (millis() - t < 300);
 
     assertEqual(s_button_clicks, 3);
 }


### PR DESCRIPTION
### Problem

This PR fixes the `SYSTEM_04_button_mirror` test from the `wiring/no_fixture` suite.

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)