### PR TITLE
Fix wiring/networking test for Core

### DIFF
--- a/user/tests/wiring/networking/udp_ntp_client.cpp
+++ b/user/tests/wiring/networking/udp_ntp_client.cpp
@@ -79,15 +79,16 @@ unsigned long getNTPClientTime(void)
 
     uint32_t _millis = millis();
 
-#if Wiring_WiFi
-    timeServer = WiFi.resolve("time-a.timefreq.bldrdoc.gov");
-#elif Wiring_Cellular
-    timeServer = Cellular.resolve("time-a.timefreq.bldrdoc.gov");
-#endif
-
     // timeout after 10 secs
     while(millis() - _millis < 10000)
     {
+
+#if Wiring_WiFi
+        timeServer = WiFi.resolve("time-a.timefreq.bldrdoc.gov");
+#elif Wiring_Cellular
+        timeServer = Cellular.resolve("time-a.timefreq.bldrdoc.gov");
+#endif
+
         sendNTPpacket(timeServer); // send an NTP packet to a time server
 
         delay(1000);


### PR DESCRIPTION
### Problem

`wiring/networking` test not resolving IP first try for Core

### Solution

Make the test more reliable by retrying the resolving step along with the sending and receiving steps over 10 seconds.

### Steps to Test

Run `wiring/networking` for Core (and other platforms)
```
make clean all -s TEST=wiring/networking PLATFORM=core COMPILE_LTO=y program-dfu
```

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [x] (N/A) Added documentation
- [x] (N/A) Added to CHANGELOG.md after merging (add links to docs and issues)
