### PR TITLE
Enable USB Serial by default

### DIFF
--- a/hal/src/nRF52840/usb_hal.cpp
+++ b/hal/src/nRF52840/usb_hal.cpp
@@ -113,6 +113,7 @@ void USB_USART_LineCoding_BitRate_Handler(void (*handler)(uint32_t bitRate))
 
 int32_t HAL_USB_USART_LineCoding_BitRate_Handler(void (*handler)(uint32_t bitRate), void* reserved) {
     // Enable Serial by default
+    HAL_USB_USART_Init(HAL_USB_USART_SERIAL, nullptr);
     HAL_USB_USART_Begin(HAL_USB_USART_SERIAL, 9600, NULL);
     usb_hal_set_bit_rate_changed_handler(handler);
     return 0;


### PR DESCRIPTION
### Problem

USB Serial on Gen 3 devices is not enabled by default until `Serial.begin()` is called. This behavior differs from Gen 2 devices.

### Solution

Implicitly enable USB Serial in `HAL_USB_USART_LineCoding_BitRate_Handler()`.

### Steps to Test

1. Flash an app that doesn't use `Serial`
2. The device should still attach correctly with a Serial port available

### Example App

N/A

### References

N/A

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
