### PR TITLE
Execute button and OOM event handlers synchronously

### DIFF
--- a/system/inc/system_event.h
+++ b/system/inc/system_event.h
@@ -97,6 +97,12 @@ enum SystemEventsParam {
     time_changed_sync = 1
 };
 
+/**
+ * Flags altering the behavior of the `system_notify_event()` function.
+ */
+enum SystemNotifyEventFlag {
+    NOTIFY_SYNCHRONOUSLY = 0x01
+};
 
 /**
  * Subscribes to the system events given
@@ -126,5 +132,7 @@ void system_notify_time_changed(uint32_t data, void* reserved, void* reserved1);
  * @param event
  * @param data
  * @param pointer
+ * @param flags Event flags as defined by the `SystemNotifyEventFlag` enum.
  */
-void system_notify_event(system_event_t event, uint32_t data=0, void* pointer=nullptr, void (*fn)(void* data)=nullptr, void* fndata=nullptr);
+void system_notify_event(system_event_t event, uint32_t data = 0, void* pointer = nullptr,
+        void (*fn)(void* data) = nullptr, void* fndata = nullptr, unsigned flags = 0);

--- a/system/src/main.cpp
+++ b/system/src/main.cpp
@@ -244,7 +244,7 @@ void reset_button_click()
     button_current_clicks = 0;
     CLR_BUTTON_TIMEOUT();
     if (clicks > 0) {
-        system_notify_event(button_final_click, clicks);
+        system_notify_event(button_final_click, clicks, nullptr, nullptr, nullptr, NOTIFY_SYNCHRONOUSLY);
         button_final_clicks = clicks;
 #if Wiring_SetupButtonUX
         // Certain numbers of clicks can be processed directly in ISR
@@ -266,7 +266,7 @@ void handle_button_click(uint16_t depressed_duration)
             ARM_BUTTON_TIMEOUT(1000);
             reset = false;
         }
-        system_notify_event(button_click, button_current_clicks);
+        system_notify_event(button_click, button_current_clicks, nullptr, nullptr, nullptr, NOTIFY_SYNCHRONOUSLY);
     }
     if (reset) {
         reset_button_click();
@@ -288,7 +288,7 @@ void HAL_Notify_Button_State(uint8_t button, uint8_t pressed)
             pressed_time = HAL_Timer_Get_Milli_Seconds();
             if (!wasListeningOnButtonPress)             // start of button press
             {
-                system_notify_event(button_status, 0);
+                system_notify_event(button_status, 0, nullptr, nullptr, nullptr, NOTIFY_SYNCHRONOUSLY);
             }
         }
         else if (pressed_time > 0)
@@ -297,7 +297,7 @@ void HAL_Notify_Button_State(uint8_t button, uint8_t pressed)
             uint16_t depressed_duration = release_time - pressed_time;
 
             if (!network.listening()) {
-                system_notify_event(button_status, depressed_duration);
+                system_notify_event(button_status, depressed_duration, nullptr, nullptr, nullptr, NOTIFY_SYNCHRONOUSLY);
                 handle_button_click(depressed_duration);
             }
             pressed_time = 0;

--- a/system/src/main.cpp
+++ b/system/src/main.cpp
@@ -500,7 +500,7 @@ void handle_out_of_memory(size_t requested) {
 	}
 	else {
 		recurse = true;
-		system_notify_event(out_of_memory, requested);
+		system_notify_event(out_of_memory, requested, nullptr, nullptr, nullptr, NOTIFY_SYNCHRONOUSLY);
 		recurse = false;
 	}
 }

--- a/system/src/system_event.cpp
+++ b/system/src/system_event.cpp
@@ -61,9 +61,6 @@ struct SystemEventSubscription {
 std::vector<SystemEventSubscription> subscriptions;
 
 void system_notify_event_impl(system_event_t event, uint32_t data, void* pointer, void (*fn)(void* data), void* fndata) {
-    APPLICATION_THREAD_CONTEXT_ASYNC(system_notify_event_impl(event, data, pointer, fn, fndata));
-    // run event notifications on the application thread
-
     for (const SystemEventSubscription& subscription : subscriptions) {
         subscription.notify(event, data, pointer);
     }
@@ -91,7 +88,8 @@ class SystemEventTask : public ISRTaskQueue::Task {
      * Notify the system event encoded in this class.
      */
     void notify() {
-        system_notify_event_impl(event_, data_, pointer_, fn_, fndata_);
+        // run event notifications on the application thread
+        APPLICATION_THREAD_CONTEXT_ASYNC(system_notify_event_impl(event_, data_, pointer_, fn_, fndata_));
         system_pool_free(this, nullptr);
     }
 
@@ -132,22 +130,21 @@ void system_unsubscribe_event(system_event_t events, system_event_handler_t* han
 {
 }
 
-/**
- * Notifes all subscribers about an event.
- * @param event
- * @param data
- * @param pointer
- */
-void system_notify_event(system_event_t event, uint32_t data, void* pointer, void (*fn)(void* data), void* fndata) {
-  if (HAL_IsISR()) {
-      void* space = (system_pool_alloc(sizeof(SystemEventTask), nullptr));
-      if (space) {
-          auto task = new (space) SystemEventTask(event, data, pointer, fn, fndata);
-          SystemISRTaskQueue.enqueue(task);
-      };
-  } else {
-      system_notify_event_impl(event, data, pointer, fn, fndata);
-  }
+void system_notify_event(system_event_t event, uint32_t data, void* pointer, void (*fn)(void* data), void* fndata,
+        unsigned flags) {
+    // TODO: Add an API that would allow user applications to control which event handlers can be
+    // executed synchronously, possibly in the context of an ISR
+    if (flags & NOTIFY_SYNCHRONOUSLY) {
+        system_notify_event_impl(event, data, pointer, fn, fndata);
+    } else if (HAL_IsISR()) {
+        void* space = (system_pool_alloc(sizeof(SystemEventTask), nullptr));
+        if (space) {
+            auto task = new (space) SystemEventTask(event, data, pointer, fn, fndata);
+            SystemISRTaskQueue.enqueue(task);
+        };
+    } else {
+        APPLICATION_THREAD_CONTEXT_ASYNC(system_notify_event_impl(event, data, pointer, fn, fndata));
+    }
 }
 
 void system_notify_time_changed(uint32_t data, void* reserved, void* reserved1) {

--- a/user/tests/wiring/no_fixture/system.cpp
+++ b/user/tests/wiring/no_fixture/system.cpp
@@ -112,12 +112,7 @@ test(SYSTEM_04_button_mirror)
     EXTI_GenerateSWInterrupt(pinmap[D1].gpio_pin);
     delay(300);
     pinMode(D1, INPUT_PULLUP);
-
-    // Make sure all asynchronous events get processed by the application thread
-    const auto t = millis();
-    do {
-        Particle.process();
-    } while (millis() - t < 300);
+    delay(300);
 
     assertEqual(s_button_clicks, 3);
 }

--- a/user/tests/wiring/no_fixture/system.cpp
+++ b/user/tests/wiring/no_fixture/system.cpp
@@ -212,7 +212,8 @@ test(SYSTEM_07_fragmented_heap) {
 
 	unregister_oom();
 	register_oom();
-	block* b = new block[2];  // no room for 2 blocks
+	const size_t BLOCKS_TO_MALLOC = 3;
+	block* b = new block[BLOCKS_TO_MALLOC];  // no room for 3 blocks, memory is clearly fragmented
 	delete b;
 
 	// free the remaining blocks
@@ -222,12 +223,12 @@ test(SYSTEM_07_fragmented_heap) {
 		delete b;
 	}
 
-	assertMoreOrEqual(half_fragment_block_size, sizeof(block));
-	assertLessOrEqual(half_fragment_block_size, 2*sizeof(block)+8 /* 8 byte overhead */);
+	assertMoreOrEqual(half_fragment_block_size, sizeof(block)); // there should definitely be one block available
+	assertLessOrEqual(half_fragment_block_size, BLOCKS_TO_MALLOC*sizeof(block)-1); // we expect malloc of 3 blocks to fail, so this better allow up to that size less 1
 	assertMoreOrEqual(half_fragment_free, low_heap+(sizeof(block)*count));
 
 	assertTrue(oomEventReceived);
-	assertMoreOrEqual(oomSizeReceived, sizeof(block)*2);
+	assertMoreOrEqual(oomSizeReceived, sizeof(block)*BLOCKS_TO_MALLOC);
 }
 
 test(SYSTEM_08_out_of_memory_not_raised_for_0_size_malloc)


### PR DESCRIPTION
### Problem

Prior to the changes introduced in https://github.com/particle-iot/firmware/pull/1600, there was a bug in `system_notify_event()` that was causing a system panic in multithreaded applications when a button event was generated. That PR fixed the problem by making all button handlers asynchronous, which, however, is a breaking change, and we'd like to avoid introducing breaking changes at this point.

### Solution

- Execute button event handlers synchronously in the ISR. This matches the behavior of a single-threaded firmware in 0.6.x and 0.7.0.
- Also makes the out_of_memory event synchronous.
- Make sure `system_notify_event()` doesn't attempt to allocate memory in an ISR.

**Note:** This is a temporary solution. Ideally, it should be up to an application developer to decide which event handlers need to be executed synchronously, even in the context of an ISR if necessary.

### Steps to Test

- `wiring/no_fixture` (with and without `USE_THREADING=y`)
- `tests/app/button_event`

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)