### PR TITLE
Fixes an assertion failure (SOS 10) with Mesh.subscribe() and threading enabled

### DIFF
--- a/wiring/src/spark_wiring_udp_posix.cpp
+++ b/wiring/src/spark_wiring_udp_posix.cpp
@@ -218,7 +218,7 @@ int UDP::beginPacket(const char *host, uint16_t port) {
 }
 
 int UDP::beginPacket(IPAddress ip, uint16_t port) {
-	LOG(TRACE, "begin packet %s#%d", ip.toString().c_str(), port);
+	LOG_DEBUG(TRACE, "begin packet %s#%d", ip.toString().c_str(), port);
     // default behavior previously was to use a 512 byte buffer, so instantiate that if not already done
     if (!_buffer && _buffer_size) {
         setBuffer(_buffer_size);
@@ -237,7 +237,7 @@ int UDP::endPacket() {
 }
 
 int UDP::sendPacket(const uint8_t* buffer, size_t buffer_size, IPAddress remoteIP, uint16_t port) {
-    LOG(TRACE, "sendPacket size %d, %s#%d", buffer_size, remoteIP.toString().c_str(), port);
+    LOG_DEBUG(TRACE, "sendPacket size %d, %s#%d", buffer_size, remoteIP.toString().c_str(), port);
 	sockaddr_storage s = {};
     detail::ipAddressPortToSockaddr(remoteIP, port, (struct sockaddr*)&s);
     if (s.ss_family == AF_UNSPEC) {
@@ -296,7 +296,7 @@ int UDP::receivePacket(uint8_t* buffer, size_t size, system_tick_t timeout) {
         ret = sock_recvfrom(_sock, buffer, size, flags, (struct sockaddr*)&saddr, &slen);
         if (ret >= 0) {
             detail::sockaddrToIpAddressPort((const struct sockaddr*)&saddr, _remoteIP, &_remotePort);
-            LOG(TRACE, "received %d bytes from %s#%d", ret, _remoteIP.toString().c_str(), _remotePort);
+            LOG_DEBUG(TRACE, "received %d bytes from %s#%d", ret, _remoteIP.toString().c_str(), _remotePort);
         }
     }
     return ret;


### PR DESCRIPTION
### Problem

The following app will trigger an [assertion failure](https://github.com/particle-iot/openthread/blob/release/20181217-particle/src/core/net/netif.cpp#L124) in OpenThread:

```cpp
SYSTEM_THREAD(ENABLED);
void setup() {
    Mesh.subscribe("test", [](const char* a, const char* b) {
    });
}
```

### Solution

This is a side-effect of OpenThread upgrade. It was previously possible to manage multicast subscriptions even if OpenThread netif was down or not fully up. In order to resolve this issue, we are adding a check for `otIp6IsEnabled()` in `OpenThreadNetif::mldMacFilterCb()` that manages multicast subscription state between LwIP and OpenThread. If OpenThread netif is down, we will keep them stored and will synchronize the state once it comes up.

This PR also enables wiring `UDP` logs only in `DEBUG_BUILD=y` builds, otherwise they pollute the logging output too much.

### Steps to Test

Flash the test application, confirm that the device does not go into SOS 10 (assertion failure).

### Example App

N/A

### References

- [CH26693]

---

### Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [x] Problem and Solution clearly stated
- [x] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
